### PR TITLE
Moving common health checks to the library

### DIFF
--- a/health_checks.js
+++ b/health_checks.js
@@ -1,0 +1,116 @@
+/* -----------------------------------------------------------------------------
+ * @copyright (C) 2018, Alert Logic, Inc
+ * @doc
+ *
+ * Halth check functions common for all collectors
+ *
+ * @end
+ * -----------------------------------------------------------------------------
+ */
+
+const AWS = require('aws-sdk');
+const async = require('async');
+
+
+/**
+ * checks status of CF, returns error in case if it's in failed state, returns error.
+ * All custom healthchecks should follow the same interface as this function.
+ *
+ * @function
+ *
+ * @param {Object} event - checkin event for Lambda function, can be used to send needed parameters for health checks. Example: stackName.
+ * @param {Object} context - context of Lambda's function.
+ * @param {function} callback - callback, which is called by health check when it's done.
+ *
+ * @returns {function} callback(err)
+ *
+ *                      {ErrorMsg}  err        - The ErrorMsg object if an error occurred, null otherwise.
+ *
+ */
+
+function checkCloudFormationStatus(event, context, callback) {
+    var stackName = event.StackName;
+    var cloudformation = new AWS.CloudFormation();
+    cloudformation.describeStacks({StackName: stackName}, function(err, data) {
+        if (err) {
+            return callback(errorMsg('ALAWS00001', stringify(err)));
+        } else {
+            var stackStatus = data.Stacks[0].StackStatus;
+            if (stackStatus === 'CREATE_COMPLETE' ||
+                stackStatus === 'UPDATE_COMPLETE' ||
+                stackStatus === 'UPDATE_IN_PROGRESS' ||
+                stackStatus === 'UPDATE_ROLLBACK_COMPLETE' ||
+                stackStatus === 'UPDATE_ROLLBACK_IN_PROGRESS' ||
+                stackStatus === 'UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS' ||
+                stackStatus === 'REVIEW_IN_PROGRESS') {
+                return callback(null);
+            } else {
+                return callback(errorMsg('ALAWS00002', 'CF stack has wrong status: ' + stackStatus));
+            }
+        }
+    });
+}
+
+function getHealthStatus(event, context, customChecks, callback) {
+    customChecksFuns = customChecks.map(f => function(asyncCallback) {
+        f(event, context, asyncCallback)
+    });
+    async.parallel([
+        function(asyncCallback) {
+            checkCloudFormationStatus(event, context, asyncCallback);
+        }
+    ].concat(customChecksFuns),
+    function(errMsg) {
+        var status = {};
+        if (errMsg) {
+            console.warn('ALAWS00001 Health check failed with',  errMsg);
+            status = {
+                status: errMsg.status,
+                error_code: errMsg.code,
+                details: [errMsg.details]
+            };
+        } else {
+            status = {
+                status: 'ok',
+                details: []
+            };
+        }
+        return callback(status);
+    });
+}
+
+
+function stringify(jsonObj) {
+    return JSON.stringify(jsonObj, null, 0);
+}
+
+
+/**
+ * @typedef {Object} ErrorMsg
+ * @property {string} status - status of healtcheck (ok, warning, error).
+ * @property {string} code - unique error code.
+ * @property {string} details - description of particular error.
+ *
+*/
+
+/**
+ * @function
+ *
+ * @param {string} code - error code
+ * @param {string} message - error message
+ *
+ * @returns {ErrorMsg} returns error message object
+ */
+
+function errorMsg(code, message) {
+    return {
+        status: 'error',
+        code: code,
+        details: message
+    };
+}
+
+module.exports = {
+    getHealthStatus : getHealthStatus,
+    errorMsg : errorMsg
+};

--- a/test/collector_mock.js
+++ b/test/collector_mock.js
@@ -76,33 +76,96 @@ const DEREG_URL = REG_URL;
 const DEREG_PARAMS = REG_PARAMS;
 
 const CHECKIN_URL = '/aws/cwe/checkin/123456789012/us-east-1/' + encodeURIComponent(FUNCTION_NAME);
-const CHECKIN_PARAMS = {
-    'status':'ok',
-    'details':[],
-    'statistics': [
-        {
-            'Label':'Invocations',
-            'Datapoints':[
-                {'Timestamp':'2017-11-21T16:40:00Z','Sum':1,'Unit':'Count'}
-            ]
-        }
-    ]
+// const CHECKIN_PARAMS = {
+//     'status':'ok',
+//     'details':[],
+//     'statistics': [
+//         {
+//             'Label':'Invocations',
+//             'Datapoints':[
+//                 {'Timestamp':'2017-11-21T16:40:00Z','Sum':1,'Unit':'Count'}
+//             ]
+//         }
+//     ]
+// };
+const CHECKIN_TEST_EVENT = {
+    'RequestType': 'ScheduledEvent',
+    'Type': 'Checkin',
+    'AwsAccountId': '353333894008',
+    'StackName' : STACK_NAME,
+    'Region' : 'us-east-1'
 };
+
+
 const CHECKIN_AZCOLLECT_QUERY = {
     body: {
         version: '1.0.0',
         status: 'ok',
         error_code: undefined,
         details: [],
-        statistics: [
-            {
-                'Label':'Invocations',
-                'Datapoints':[
-                    {'Timestamp':'2017-11-21T16:40:00Z','Sum':1,'Unit':'Count'}
-                ]
-            }
-        ]
+        statistics: undefined
     }
+};
+
+const CF_DESCRIBE_STACKS_RESPONSE = {
+    'ResponseMetadata': {
+        'RequestId': 'f9f5e0e7-be24-11e7-9891-49fc9e4a2c65'
+    },
+    'Stacks': [
+        {
+            'StackId': STACK_ID,
+            'StackName': STACK_NAME,
+            'Description': 'Alert Logic template',
+            'Parameters': [],
+            'CreationTime': '2017-10-30T14:27:59.848Z',
+            'RollbackConfiguration': {},
+            'StackStatus': 'CREATE_COMPLETE',
+            'DisableRollback': false,
+            'NotificationARNs': [],
+            'Capabilities': [
+                'CAPABILITY_IAM'
+            ],
+            'Outputs': [],
+            'Tags': [],
+            'EnableTerminationProtection': false
+        }
+    ]
+};
+
+const CHECKIN_ERROR_AZCOLLECT_QUERY = {
+    body: {
+        version: '1.0.0',
+        status: 'error',
+        error_code: 'ALAWS00002',
+        details: [ 'CF stack has wrong status: FAILED' ],
+        statistics: undefined
+    }
+};
+
+const CF_DESCRIBE_STACKS_FAILED_RESPONSE = {
+  'ResponseMetadata': {
+    'RequestId': 'f9f5e0e7-be24-11e7-9891-49fc9e4a2c65'
+  },
+  'Stacks': [
+    {
+      'StackId': STACK_ID,
+      'StackName': STACK_NAME,
+      'Description': 'Alert Logic template',
+      'Parameters': [
+      ],
+      'CreationTime': '2017-10-30T14:27:59.848Z',
+      'RollbackConfiguration': {},
+      'StackStatus': 'FAILED',
+      'DisableRollback': false,
+      'NotificationARNs': [],
+      'Capabilities': [
+        'CAPABILITY_IAM'
+      ],
+      'Outputs': [],
+      'Tags': [],
+      'EnableTerminationProtection': false
+    }
+  ]
 };
 
 module.exports = {
@@ -110,6 +173,7 @@ module.exports = {
     FUNCTION_NAME : FUNCTION_NAME,
     S3_BUCKET : S3_BUCKET,
     S3_ZIPFILE : S3_ZIPFILE,
+    STACK_NAME : STACK_NAME,
 
     REGISTRATION_TEST_EVENT : REGISTRATION_TEST_EVENT,
     REG_URL : REG_URL,
@@ -121,6 +185,9 @@ module.exports = {
     DEREG_PARAMS : DEREG_PARAMS,
 
     CHECKIN_URL : CHECKIN_URL,
-    CHECKIN_PARAMS : CHECKIN_PARAMS,
-    CHECKIN_AZCOLLECT_QUERY : CHECKIN_AZCOLLECT_QUERY
+    CHECKIN_TEST_EVENT : CHECKIN_TEST_EVENT,
+    CHECKIN_AZCOLLECT_QUERY : CHECKIN_AZCOLLECT_QUERY,
+    CF_DESCRIBE_STACKS_RESPONSE : CF_DESCRIBE_STACKS_RESPONSE,
+    CHECKIN_ERROR_AZCOLLECT_QUERY : CHECKIN_ERROR_AZCOLLECT_QUERY,
+    CF_DESCRIBE_STACKS_FAILED_RESPONSE: CF_DESCRIBE_STACKS_FAILED_RESPONSE
 };


### PR DESCRIPTION
### Problem
there are health checks that are common to every collector, and now it's just copied everywhere

### Solution
* DRY it!
* List with custom health checks is added to the init parameters of collector

