### PR TITLE
use al-collector-js index file for classes

### DIFF
--- a/al_aws_collector.js
+++ b/al_aws_collector.js
@@ -15,7 +15,7 @@ const zlib = require('zlib');
 const async = require('async');
 const response = require('cfn-response');
 
-const m_alServiceC = require('al-collector-js/al_servicec');
+const m_alServiceC = require('al-collector-js');
 const m_alAws = require('./al_aws');
 const m_healthChecks = require('./health_checks');
 const m_stats = require('./statistics');

--- a/test/al_aws_collector_test.js
+++ b/test/al_aws_collector_test.js
@@ -4,7 +4,7 @@ const sinon = require('sinon');
 const m_response = require('cfn-response');
 
 const AlAwsCollector = require('../al_aws_collector');
-var m_servicec = require('al-collector-js/al_servicec');
+var m_servicec = require('al-collector-js');
 const m_healthChecks = require('../health_checks');
 var AWS = require('aws-sdk-mock');
 const colMock = require('./collector_mock');


### PR DESCRIPTION
### Problem Description
We include this library from others by using direct links to filenames:

```
const m_servicec = require('al-collector-js/al_servicec');
```

This is bad practice as it increase lib interface dependency.


### Solution Description
Use index file with specific names
