### PR TITLE
use al-collector-js index file for classes

### DIFF
--- a/al_aws_collector.js
+++ b/al_aws_collector.js
@@ -15,7 +15,7 @@ const zlib = require('zlib');
 const async = require('async');
 const response = require('cfn-response');
 
-const m_alServiceC = require('al-collector-js/al_servicec');
+const m_alCollector = require('al-collector-js');
 const m_alAws = require('./al_aws');
 const m_healthChecks = require('./health_checks');
 const m_stats = require('./statistics');
@@ -95,10 +95,10 @@ class AlAwsCollector {
                 process.env.al_data_residency :
                 'default';
         this._alAzcollectEndpoint = process.env.azollect_api;
-        this._aimsc = new m_alServiceC.AimsC(process.env.al_api, aimsCreds);
-        this._endpointsc = new m_alServiceC.EndpointsC(process.env.al_api, this._aimsc);
-        this._azcollectc = new m_alServiceC.AzcollectC(process.env.azollect_api, this._aimsc, collectorType);
-        this._ingestc = new m_alServiceC.IngestC(process.env.ingest_api, this._aimsc, 'lambda_function');
+        this._aimsc = new m_alCollector.AimsC(process.env.al_api, aimsCreds);
+        this._endpointsc = new m_alCollector.EndpointsC(process.env.al_api, this._aimsc);
+        this._azcollectc = new m_alCollector.AzcollectC(process.env.azollect_api, this._aimsc, collectorType);
+        this._ingestc = new m_alCollector.IngestC(process.env.ingest_api, this._aimsc, 'lambda_function');
         this._formatFun = formatFun;
         this._customHealthChecks = healthCheckFuns;
         this._customStatsFuns = statsFuns;

--- a/test/al_aws_collector_test.js
+++ b/test/al_aws_collector_test.js
@@ -4,7 +4,7 @@ const sinon = require('sinon');
 const m_response = require('cfn-response');
 
 const AlAwsCollector = require('../al_aws_collector');
-var m_servicec = require('al-collector-js/al_servicec');
+var m_alCollector = require('al-collector-js');
 const m_healthChecks = require('../health_checks');
 var AWS = require('aws-sdk-mock');
 const colMock = require('./collector_mock');
@@ -19,7 +19,7 @@ var alserviceStub = {};
 var responseStub = {};
 
 function setAlServiceStub() {
-    alserviceStub.get = sinon.stub(m_servicec.AlServiceC.prototype, 'get').callsFake(
+    alserviceStub.get = sinon.stub(m_alCollector.AlServiceC.prototype, 'get').callsFake(
         function fakeFn(path, extraOptions) {
             return new Promise(function(resolve, reject) {
                 var ret = null;
@@ -40,13 +40,13 @@ function setAlServiceStub() {
                 return resolve(ret);
             });
         });
-    alserviceStub.post = sinon.stub(m_servicec.AlServiceC.prototype, 'post').callsFake(
+    alserviceStub.post = sinon.stub(m_alCollector.AlServiceC.prototype, 'post').callsFake(
             function fakeFn(path, extraOptions) {
                 return new Promise(function(resolve, reject) {
                     return resolve();
                 });
             });
-    alserviceStub.del = sinon.stub(m_servicec.AlServiceC.prototype, 'deleteRequest').callsFake(
+    alserviceStub.del = sinon.stub(m_alCollector.AlServiceC.prototype, 'deleteRequest').callsFake(
             function fakeFn(path) {
                 return new Promise(function(resolve, reject) {
                     return resolve();
@@ -55,19 +55,19 @@ function setAlServiceStub() {
 }
 
 function setAlServiceErrorStub() {
-    alserviceStub.get = sinon.stub(m_servicec.AlServiceC.prototype, 'get').callsFake(
+    alserviceStub.get = sinon.stub(m_alCollector.AlServiceC.prototype, 'get').callsFake(
         function fakeFn(path, extraOptions) {
             return new Promise(function(resolve, reject) {
                 return reject('get error');
             });
         });
-    alserviceStub.post = sinon.stub(m_servicec.AlServiceC.prototype, 'post').callsFake(
+    alserviceStub.post = sinon.stub(m_alCollector.AlServiceC.prototype, 'post').callsFake(
             function fakeFn(path, extraOptions) {
                 return new Promise(function(resolve, reject) {
                     return reject('post error');
                 });
             });
-    alserviceStub.del = sinon.stub(m_servicec.AlServiceC.prototype, 'deleteRequest').callsFake(
+    alserviceStub.del = sinon.stub(m_alCollector.AlServiceC.prototype, 'deleteRequest').callsFake(
             function fakeFn(path) {
                 return new Promise(function(resolve, reject) {
                     return reject('delete error');
@@ -305,14 +305,14 @@ describe('al_aws_collector tests', function(done) {
         var ingestCSecmsgsStub;
         var ingestCVpcFlowStub;
         before(function() {
-            ingestCSecmsgsStub = sinon.stub(m_servicec.IngestC.prototype, 'sendSecmsgs').callsFake(
+            ingestCSecmsgsStub = sinon.stub(m_alCollector.IngestC.prototype, 'sendSecmsgs').callsFake(
                 function fakeFn(data, callback) {
                     return new Promise (function(resolve, reject) {
                         resolve(null);
                     });
                 });
 
-            ingestCVpcFlowStub = sinon.stub(m_servicec.IngestC.prototype, 'sendVpcFlow').callsFake(
+            ingestCVpcFlowStub = sinon.stub(m_alCollector.IngestC.prototype, 'sendVpcFlow').callsFake(
                 function fakeFn(data, callback) {
                     return new Promise (function(resolve, reject) {
                         resolve(null);


### PR DESCRIPTION
### Problem Description
We include this library from others by using direct links to filenames:

```
const m_servicec = require('al-collector-js/al_servicec');
```

This is bad practice as it increase lib interface dependency.


### Solution Description
Use index file with specific names
