### PR TITLE
add gaurd to stop injest call if data is falsey

### DIFF
--- a/al_aws_collector.js
+++ b/al_aws_collector.js
@@ -208,6 +208,7 @@ class AlAwsCollector {
         if(!data){
             console.warn('data appears to be empty, skipping send to ingest');
             callback(null);
+            return;
         }
 
         zlib.deflate(data, function(compressionErr, compressed) {

--- a/al_aws_collector.js
+++ b/al_aws_collector.js
@@ -203,7 +203,13 @@ class AlAwsCollector {
     send(data, callback){
         var collector = this;
         var ingestType = collector._ingestType;
-        
+
+        // if the data is falsey, just return the callback
+        if(!data){
+            console.warn('data appears to be empty, skipping send to ingest');
+            callback(null);
+        }
+
         zlib.deflate(data, function(compressionErr, compressed) {
             if (compressionErr) {
                 return callback(compressionErr);

--- a/test/al_aws_collector_test.js
+++ b/test/al_aws_collector_test.js
@@ -324,7 +324,7 @@ describe('al_aws_collector tests', function(done) {
     describe('mocking ingestC', function(done) {
         var ingestCSecmsgsStub;
         var ingestCVpcFlowStub;
-        before(function() {
+        beforeEach(function() {
             ingestCSecmsgsStub = sinon.stub(m_alCollector.IngestC.prototype, 'sendSecmsgs').callsFake(
                 function fakeFn(data, callback) {
                     return new Promise (function(resolve, reject) {
@@ -340,9 +340,22 @@ describe('al_aws_collector tests', function(done) {
                 });
         });
         
-        after(function() {
+        afterEach(function() {
             ingestCSecmsgsStub.restore();
             ingestCVpcFlowStub.restore();
+        });
+
+        it('dont send if data is falsey', function(done) {
+            AlAwsCollector.load().then(function(creds) {
+                var collector = new AlAwsCollector(
+                    context, 'cwe', AlAwsCollector.IngestTypes.SECMSGS, '1.0.0', creds);
+                var data = '';
+                collector.send(data, function(error) {
+                    assert.ifError(error);
+                    sinon.assert.notCalled(ingestCSecmsgsStub);
+                    done();
+                });
+            });
         });
         
         it('send secmsgs success', function(done) {


### PR DESCRIPTION
### Problem Description
Sending a blank post body to ingest was causing ingest to return a 400.

### Solution Description
in the `send` function, check if the data is falsey. If it is, just return the callback.

