### PR TITLE
Stop blank ingest calls

### DIFF
--- a/al_aws_collector.js
+++ b/al_aws_collector.js
@@ -208,6 +208,7 @@ class AlAwsCollector {
         if(!data){
             console.warn('data appears to be empty, skipping send to ingest');
             callback(null);
+            return;
         }
 
         zlib.deflate(data, function(compressionErr, compressed) {

--- a/al_aws_collector.js
+++ b/al_aws_collector.js
@@ -204,11 +204,14 @@ class AlAwsCollector {
         var collector = this;
         var ingestType = collector._ingestType;
 
-        // if the data is falsey, just return the callback
-        if(!data){
-            console.warn('data appears to be empty, skipping send to ingest');
-            callback(null);
-            return;
+        // if the data is falsey, and empty array or an empty object, just return the callback.
+        const stringifiedData = JSON.stringify(data);
+        if(
+            !data ||
+            stringifiedData === '{}' ||
+            stringifiedData === '[]'
+        ){
+            return callback(null);
         }
 
         zlib.deflate(data, function(compressionErr, compressed) {

--- a/al_aws_collector.js
+++ b/al_aws_collector.js
@@ -199,18 +199,12 @@ class AlAwsCollector {
                 return response.send(event, context, response.FAILED, {Error: exception});
             });
     }
-    
+
     send(data, callback){
         var collector = this;
         var ingestType = collector._ingestType;
 
-        // if the data is falsey, and empty array or an empty object, just return the callback.
-        const stringifiedData = JSON.stringify(data);
-        if(
-            !data ||
-            stringifiedData === '{}' ||
-            stringifiedData === '[]'
-        ){
+        if(!data){
             return callback(null);
         }
 

--- a/al_aws_collector.js
+++ b/al_aws_collector.js
@@ -203,7 +203,13 @@ class AlAwsCollector {
     send(data, callback){
         var collector = this;
         var ingestType = collector._ingestType;
-        
+
+        // if the data is falsey, just return the callback
+        if(!data){
+            console.warn('data appears to be empty, skipping send to ingest');
+            callback(null);
+        }
+
         zlib.deflate(data, function(compressionErr, compressed) {
             if (compressionErr) {
                 return callback(compressionErr);

--- a/test/al_aws_collector_test.js
+++ b/test/al_aws_collector_test.js
@@ -318,7 +318,7 @@ describe('al_aws_collector tests', function() {
     describe('mocking ingestC', function() {
         var ingestCSecmsgsStub;
         var ingestCVpcFlowStub;
-        before(function() {
+        beforeEach(function() {
             ingestCSecmsgsStub = sinon.stub(m_alCollector.IngestC.prototype, 'sendSecmsgs').callsFake(
                 function fakeFn(data, callback) {
                     return new Promise (function(resolve, reject) {
@@ -334,9 +334,22 @@ describe('al_aws_collector tests', function() {
                 });
         });
         
-        after(function() {
+        afterEach(function() {
             ingestCSecmsgsStub.restore();
             ingestCVpcFlowStub.restore();
+        });
+
+        it('dont send if data is falsey', function(done) {
+            AlAwsCollector.load().then(function(creds) {
+                var collector = new AlAwsCollector(
+                    context, 'cwe', AlAwsCollector.IngestTypes.SECMSGS, '1.0.0', creds);
+                var data = '';
+                collector.send(data, function(error) {
+                    assert.ifError(error);
+                    sinon.assert.notCalled(ingestCSecmsgsStub);
+                    done();
+                });
+            });
         });
         
         it('send secmsgs success', function(done) {


### PR DESCRIPTION
### Problem Description
There was the potential to send a blank post body to ingest, which was causing an error in ingest.

### Solution Description
The checks to see if data is falsey, an empty object, or an epty array. It does not call ingest if this is true.

