### PR TITLE
 update depnedencies and get ready to publish on NPM

### DIFF
--- a/al_aws_collector.js
+++ b/al_aws_collector.js
@@ -16,7 +16,7 @@ const async = require('async');
 const response = require('cfn-response');
 const deepEqual = require('deep-equal');
 
-const m_alCollector = require('al-collector-js');
+const m_alCollector = require('@alertlogic/al-collector-js');
 const m_alAws = require('./al_aws');
 const m_healthChecks = require('./health_checks');
 const m_stats = require('./statistics');

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "description": "Alert Logic AWS Collector Common Library",
   "repository": {
     "type": "git",
-    "url": "https://github.com/alertlogic/al-aws-collector-js#master"
+    "url": "https://github.com/alertlogic/al-aws-collector-js#npm"
   },
-  "private": true,
+  "private": false,
   "scripts": {
     "lint": "jshint --exclude \"./node_modules/*\" **/*.js",
     "test": "JUNIT_REPORT_PATH=./test/report.xml nyc --reporter=cobertura mocha --colors --reporter mocha-jenkins-reporter"

--- a/package.json
+++ b/package.json
@@ -1,18 +1,29 @@
 {
-  "name": "al-aws-collector-js",
-  "version": "1.0.0",
+  "name": "@alertlogic/al-aws-collector-js",
+  "version": "1.1.0",
+  "license": "MIT",
   "description": "Alert Logic AWS Collector Common Library",
-  "repository": {},
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/alertlogic/al-aws-collector-js#master"
+  },
   "private": true,
   "scripts": {
     "lint": "jshint --exclude \"./node_modules/*\" **/*.js",
     "test": "JUNIT_REPORT_PATH=./test/report.xml nyc --reporter=cobertura mocha --colors --reporter mocha-jenkins-reporter"
   },
+  "main": "index.js",
+  "maintainers": [
+    {
+      "name": "Alert Logic NPM Team",
+      "email": "npm@alertlogic.com"
+    }
+  ],
   "devDependencies": {
-    "aws-sdk": "*",
-    "aws-sdk-mock": "*",
-    "dotenv": "*",
-    "clone": "*",
+    "aws-sdk": "^2.441.0",
+    "aws-sdk-mock": "^4.4.0",
+    "dotenv": "^7.0.0",
+    "clone": "^2.1.2",
     "jshint": "^2.9.5",
     "mocha": "^3.5.3",
     "mocha-jenkins-reporter": "^0.3.10",
@@ -21,11 +32,11 @@
     "sinon": "^3.3.0"
   },
   "dependencies": {
-    "al-collector-js": "git://github.com/alertlogic/al-collector-js#master",
-    "cfn-response": "*",
-    "async": "*",
+    "@alertlogic/al-collector-js": "^1.1.2",
+    "cfn-response": "^1.0.1",
+    "async": "^2.6.1",
     "moment": "^2.19.2",
-    "deep-equal": "*"
+    "deep-equal": "^1.0.1"
   },
   "author": "Alert Logic Inc."
 }

--- a/test/al_aws_collector_test.js
+++ b/test/al_aws_collector_test.js
@@ -5,7 +5,7 @@ const m_response = require('cfn-response');
 const deepEqual = require('deep-equal');
 
 const AlAwsCollector = require('../al_aws_collector');
-var m_alCollector = require('al-collector-js');
+var m_alCollector = require('@alertlogic/al-collector-js');
 const m_healthChecks = require('../health_checks');
 var AWS = require('aws-sdk-mock');
 const colMock = require('./collector_mock');


### PR DESCRIPTION
### Problem Description
- Some dependencies were listed under "*"
- al-collector-js was pointing directly to the git repo
- some `package.json` needed some additional metatdata for publishing on NPM.

### Solution Description
These issues were fixed by pinning versions and pointing al-collector-js to the npm version.

