### PR TITLE
Update al-collector-js dependency

### DIFF
--- a/al_aws_collector.js
+++ b/al_aws_collector.js
@@ -267,7 +267,8 @@ class AlAwsCollector {
     
     deregister(event, custom){
         const context = this._invokeContext;
-        const regValues = Object.assign(this.getProperties(), custom);
+        let regValues = Object.assign(this.getProperties(), custom);
+        regValues.stackName = event.ResourceProperties.StackName;
 
         this._azcollectc.deregister(regValues)
             .then(resp => {

--- a/al_aws_collector.js
+++ b/al_aws_collector.js
@@ -164,7 +164,8 @@ class AlAwsCollector {
     
     register(event, custom) {
         const context = this._invokeContext;
-        const regValues = Object.assign(this.getProperties(), custom);
+        let regValues = Object.assign(this.getProperties(), custom);
+        regValues.stackName = event.ResourceProperties.StackName;
 
         async.waterfall([
             (asyncCallback) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/al-aws-collector-js",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "license": "MIT",
   "description": "Alert Logic AWS Collector Common Library",
   "repository": {
@@ -33,7 +33,7 @@
     "sinon": "^7.5.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "1.3.4",
+    "@alertlogic/al-collector-js": "1.4.0",
     "cfn-response": "1.0.1",
     "async": "3.0.1",
     "moment": "2.24.0",

--- a/test/collector_mock.js
+++ b/test/collector_mock.js
@@ -72,10 +72,14 @@ const REG_PARAMS = {
 };
 const REG_AZCOLLECT_QUERY = {
     body: {
-        cf_stack_name: STACK_NAME,
-        version: '1.0.0',
-        data_type: 'vpcflow',
-        something_else: 'testtest'
+        awsAccountId: "123456789012",
+        collectorId: "collector-id",
+        custom_fields: { data_type: "vpcflow", something_else: "testtest" },
+        dataType: "secmsgs",
+        functionName: "test-VpcFlowCollectLambdaFunction",
+        region: "us-east-1",
+        stackName: STACK_NAME,
+        version: "1.0.0"
     }
 };
 


### PR DESCRIPTION
### Solution Description
New version of `al-collector-js` passes AWS collector registration values as is.
By default get `stackName` from register/deregister events.

