### PR TITLE
Handle errors with circular references in done

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/al-aws-collector-js",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "license": "MIT",
   "description": "Alert Logic AWS Collector Common Library",
   "repository": {

--- a/test/al_aws_collector_test.js
+++ b/test/al_aws_collector_test.js
@@ -604,14 +604,7 @@ describe('al_aws_collector tests', function() {
     });
     
     describe('done() function', () => {
-        var object;
-        var newValues;
         var collector;
-        var applyConfigChangesContext = {
-            invokedFunctionArn : colMock.FUNCTION_ARN,
-            functionName : colMock.FUNCTION_NAME
-        };
-
 
         it('calls success when there is no error', () => {
 
@@ -661,8 +654,8 @@ describe('al_aws_collector tests', function() {
                 fail: (error) => error
             };
 
-            testContext = new AlAwsCollector(
-                context,
+            collector = new AlAwsCollector(
+                testContext,
                 'cwe',
                 AlAwsCollector.IngestTypes.SECMSGS,
                 '1.0.0',

--- a/test/al_aws_collector_test.js
+++ b/test/al_aws_collector_test.js
@@ -603,6 +603,78 @@ describe('al_aws_collector tests', function() {
         });
     });
     
+    describe('done() function', () => {
+        var object;
+        var newValues;
+        var collector;
+        var applyConfigChangesContext = {
+            invokedFunctionArn : colMock.FUNCTION_ARN,
+            functionName : colMock.FUNCTION_NAME
+        };
+
+
+        it('calls success when there is no error', () => {
+
+            const testContext = {
+                succeed: () => true,
+                fail: () => false
+            };
+
+            collector = new AlAwsCollector(
+                testContext,
+                'cwe',
+                AlAwsCollector.IngestTypes.SECMSGS,
+                '1.0.0',
+                colMock.AIMS_TEST_CREDS
+            );
+
+            const doneResult = collector.done();
+            assert.ok(doneResult);
+        });
+
+        it('returns errors that can be stringified in their raw state', () => {
+            const stringifialbleError = {
+                foo: "bar"
+            };
+            const testContext = {
+                succeed: () => true,
+                fail: (error) => error
+            };
+
+            collector = new AlAwsCollector(
+                testContext,
+                'cwe',
+                AlAwsCollector.IngestTypes.SECMSGS,
+                '1.0.0',
+                colMock.AIMS_TEST_CREDS
+            );
+
+            const doneResult = collector.done(stringifialbleError);
+            assert.ok(doneResult === stringifialbleError);
+        });
+
+        it('returns errors that cannot be JSON stringified as a string', () => {
+            const circRefError = {};
+            circRefError.foo = circRefError;
+            const testContext = {
+                succeed: () => true,
+                fail: (error) => error
+            };
+
+            testContext = new AlAwsCollector(
+                context,
+                'cwe',
+                AlAwsCollector.IngestTypes.SECMSGS,
+                '1.0.0',
+                colMock.AIMS_TEST_CREDS
+            );
+
+            const doneResult = collector.done(circRefError);
+            assert.ok(doneResult !== circRefError);
+            assert.ok(typeof doneResult === 'string');
+        });
+    });
+
     describe('applyConfigChanges() function', () => {
         var object;
         var newValues;


### PR DESCRIPTION
### Problem Description
Errors that are passed to this framework often contain circular references. These errors cannot be stringified by AWS, which results in the stringification error being displayed instead of the actual error. 

### Solution Description
Try to detect when these stringification errors occur before they are passed to AWS, then try to safely stringify the errors that would themselves cause an error.

