### PR TITLE
Register async

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-  - "8"
+  - "12"
 install:
   - npm install
 script:

--- a/al_aws.js
+++ b/al_aws.js
@@ -4,7 +4,7 @@
  *
  * Helper class for lambda function utility and helper methods.
  *
- * Last message ID: AWSC0102
+ * Last message ID: AWSC0104
  * @end
  * -----------------------------------------------------------------------------
  */
@@ -50,7 +50,7 @@ var getS3ConfigChanges = function(callback) {
                 let config = JSON.parse(object.Body.toString());
                 return callback(null, config);
             } catch(ex) {
-                return callback('Unable to parse config changes.')
+                return callback('AWSC0103 Unable to parse config changes.')
             }
         }
     });
@@ -158,7 +158,7 @@ var setEnv = function(vars, callback) {
 
     lambda.getFunctionConfiguration(getConfigParams, (err, config) => {
         if(err){
-            console.error('Error getting function config, environment variables were not updated', err);
+            console.error('AWSC0104 Error getting function config, environment variables were not updated', err);
             return callback(err);
         }
         var params = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/al-aws-collector-js",
-  "version": "2.0.11",
+  "version": "3.0.0",
   "license": "MIT",
   "description": "Alert Logic AWS Collector Common Library",
   "repository": {
@@ -10,7 +10,7 @@
   "private": false,
   "scripts": {
     "lint": "jshint --exclude \"./node_modules/*\" **/*.js",
-    "test": "JUNIT_REPORT_PATH=./test/report.xml nyc --reporter=cobertura mocha --colors --reporter mocha-jenkins-reporter",
+    "test": "JUNIT_REPORT_PATH=./test/report.xml nyc --reporter=cobertura mocha './test/*_test.js' --colors",
     "rel": "npm publish --access=public"
   },
   "main": "index.js",
@@ -22,14 +22,13 @@
   ],
   "devDependencies": {
     "aws-sdk": "^2.441.0",
-    "aws-sdk-mock": "^4.4.0",
+    "aws-sdk-mock": "^5.1.0",
     "clone": "^2.1.2",
     "dotenv": "^8.2.0",
     "jshint": "^2.9.5",
-    "mocha": "^6.2.2",
-    "mocha-jenkins-reporter": "^0.4.2",
+    "mocha": "^7.1.1",
     "nyc": "^14.1.1",
-    "rewire": "^4.0.1",
+    "rewire": "^5.0.0",
     "sinon": "^7.5.0"
   },
   "dependencies": {

--- a/ps_spec.yml
+++ b/ps_spec.yml
@@ -6,6 +6,8 @@ stages:
         name: PR Test
         when:
             - pull_request
+            - pull_request:
+                trigger_phrase: test it
         image: node:12
         compute_size: small
         commands:

--- a/test/al_aws_collector_test.js
+++ b/test/al_aws_collector_test.js
@@ -150,6 +150,7 @@ var formatFun = function (event, context, callback) {
 describe('al_aws_collector tests', function() {
 
     beforeEach(function(){
+        colMock.initProcessEnv();
         AWS.mock('KMS', 'decrypt', function (params, callback) {
             const data = {
                     Plaintext : 'decrypted-aims-sercret-key'
@@ -185,7 +186,7 @@ describe('al_aws_collector tests', function() {
         AlAwsCollector.load().then(function(creds) {
             var collector = new AlAwsCollector(
             mockContext, 'cwe', AlAwsCollector.IngestTypes.SECMSGS, '1.0.0', creds, function() {});
-            collector.register(colMock.REGISTRATION_TEST_EVENT, colMock.REG_PARAMS);
+            collector.registerSync(colMock.REGISTRATION_TEST_EVENT, colMock.REG_PARAMS);
         });
     });
 
@@ -204,7 +205,7 @@ describe('al_aws_collector tests', function() {
         AlAwsCollector.load().then(function(creds) {
             var collector = new AlAwsCollector(
             mockContext, 'cwe', AlAwsCollector.IngestTypes.SECMSGS, '1.0.0', creds, function() {});
-            collector.register(colMock.REGISTRATION_TEST_EVENT, colMock.REG_PARAMS);
+            collector.registerSync(colMock.REGISTRATION_TEST_EVENT, colMock.REG_PARAMS);
         });
     });
 
@@ -367,7 +368,7 @@ describe('al_aws_collector tests', function() {
         AlAwsCollector.load().then(function(creds) {
             var collector = new AlAwsCollector(
             deregisterContext, 'cwe', AlAwsCollector.IngestTypes.SECMSGS, '1.0.0', creds);
-            collector.deregister(colMock.DEREGISTRATION_TEST_EVENT, colMock.DEREG_PARAMS);
+            collector.deregisterSync(colMock.DEREGISTRATION_TEST_EVENT, colMock.DEREG_PARAMS);
         });
     });
 
@@ -693,6 +694,7 @@ describe('al_aws_collector tests', function() {
         };
 
         beforeEach(() => {
+            colMock.initProcessEnv();
             collector = new AlAwsCollector(applyConfigChangesContext, 'cwe', 
                 AlAwsCollector.IngestTypes.SECMSGS, '1.0.0', colMock.AIMS_TEST_CREDS);
             object = JSON.parse(JSON.stringify(colMock.LAMBDA_FUNCTION_CONFIGURATION));
@@ -868,6 +870,10 @@ describe('al_aws_collector tests for setDecryptedCredentials()', function() {
         rewireGetDecryptedCredentials = collectRewire.__get__('getDecryptedCredentials');
     });
 
+    beforeEach(function() {
+        colMock.initProcessEnv();
+    });
+    
     afterEach(function() {
         AWS.restore('KMS', 'decrypt');
     });
@@ -885,12 +891,9 @@ describe('al_aws_collector tests for setDecryptedCredentials()', function() {
 
     it('if AIMS_DECRYPTED_CREDS are not declared KMS decryption is called', function(done) {
         collectRewire.__set__('AIMS_DECRYPTED_CREDS', undefined);
-        collectRewire.__set__('process', {
-            env : {
-                aims_access_key_id : ACCESS_KEY_ID,
-                aims_secret_key: ENCRYPTED_SECRET_KEY_BASE64
-            }
-        });
+        process.env.aims_access_key_id = ACCESS_KEY_ID;
+        process.env.aims_secret_key = ENCRYPTED_SECRET_KEY_BASE64;
+
         AWS.mock('KMS', 'decrypt', function (data, callback) {
             assert.equal(data.CiphertextBlob, ENCRYPTED_SECRET_KEY);
             return callback(null, {Plaintext : DECRYPTED_SECRET_KEY});
@@ -907,12 +910,9 @@ describe('al_aws_collector tests for setDecryptedCredentials()', function() {
 
     it('if some error during decryption, function fails', function(done) {
         collectRewire.__set__('AIMS_DECRYPTED_CREDS', undefined);
-        collectRewire.__set__('process', {
-            env : {
-                aims_access_key_id : ACCESS_KEY_ID,
-                aims_secret_key: new Buffer('wrong_key').toString('base64')
-            }
-        });
+        process.env.aims_access_key_id = ACCESS_KEY_ID;
+        process.env.aims_secret_key = new Buffer('wrong_key').toString('base64');
+        
         AWS.mock('KMS', 'decrypt', function (data, callback) {
             assert.equal(data.CiphertextBlob, 'wrong_key');
             return callback('error', 'stack');
@@ -927,6 +927,7 @@ describe('al_aws_collector tests for setDecryptedCredentials()', function() {
 describe('al_aws_collector error tests', function() {
 
     beforeEach(function(){
+        colMock.initProcessEnv();
         AWS.mock('KMS', 'decrypt', function (params, callback) {
             const data = {
                     Plaintext : 'decrypted-aims-sercret-key'
@@ -968,7 +969,7 @@ describe('al_aws_collector error tests', function() {
         AlAwsCollector.load().then(function(creds) {
             var collector = new AlAwsCollector(
             registerContext, 'cwe', AlAwsCollector.IngestTypes.SECMSGS, '1.0.0', creds, function() {});
-            collector.register(colMock.REGISTRATION_TEST_EVENT, colMock.REG_PARAMS);
+            collector.registerSync(colMock.REGISTRATION_TEST_EVENT, colMock.REG_PARAMS);
         });
     });
 
@@ -984,7 +985,7 @@ describe('al_aws_collector error tests', function() {
         AlAwsCollector.load().then(function(creds) {
             var collector = new AlAwsCollector(
             deregisterContext, 'cwe', AlAwsCollector.IngestTypes.SECMSGS, '1.0.0', creds);
-            collector.deregister(colMock.DEREGISTRATION_TEST_EVENT, colMock.DEREG_PARAMS);
+            collector.deregisterSync(colMock.DEREGISTRATION_TEST_EVENT, colMock.DEREG_PARAMS);
         });
     });
 

--- a/test/collector_mock.js
+++ b/test/collector_mock.js
@@ -4,18 +4,24 @@ const S3_ZIPFILE = 'collector.zip';
 const S3_CONFIGURATION_BUCKET = S3_BUCKET;
 const S3_CONFIGURATION_FILE_NAME = 'configs/lambda/al-cwl-collector.json';
 const STACK_NAME = 'test-stack-01';
-process.env.AWS_REGION = 'us-east-1';
-process.env.AWS_LAMBDA_FUNCTION_NAME = FUNCTION_NAME;
-process.env.al_api = 'api.global-services.global.alertlogic.com';
-process.env.ingest_api = 'ingest.global-services.global.alertlogic.com';
-process.env.azcollect_api = 'azcollect.global-services.global.alertlogic.com';
-process.env.aims_access_key_id = 'aims-key-id';
-process.env.aims_secret_key = 'aims-secret-key-encrypted';
-process.env.aws_lambda_s3_bucket = S3_BUCKET;
-process.env.stack_name = STACK_NAME;
-process.env.aws_lambda_zipfile_name = S3_ZIPFILE;
-process.env.aws_lambda_update_config_name = S3_CONFIGURATION_FILE_NAME;
-process.env.collector_id = 'collector-id';
+const AL_API = 'api.global-services.global.alertlogic.com';
+const INGEST_API = 'ingest.global-services.global.alertlogic.com';
+const AZCOLLECT_API = 'azcollect.global-services.global.alertlogic.com';
+
+var initProcessEnv = function() {
+    process.env.AWS_REGION = 'us-east-1';
+    process.env.AWS_LAMBDA_FUNCTION_NAME = FUNCTION_NAME;
+    process.env.al_api = AL_API;
+    process.env.ingest_api = INGEST_API;
+    process.env.azcollect_api = AZCOLLECT_API;
+    process.env.aims_access_key_id = 'aims-key-id';
+    process.env.aims_secret_key = 'aims-secret-key-encrypted';
+    process.env.aws_lambda_s3_bucket = S3_BUCKET;
+    process.env.stack_name = STACK_NAME;
+    process.env.aws_lambda_zipfile_name = S3_ZIPFILE;
+    process.env.aws_lambda_update_config_name = S3_CONFIGURATION_FILE_NAME;
+    process.env.collector_id = 'collector-id';
+};
 
 
 const AIMS_TEST_CREDS = {
@@ -271,11 +277,11 @@ const LAMBDA_FUNCTION_CONFIGURATION = {
         Variables: { 
             aims_access_key_id: AIMS_TEST_CREDS.access_key_id,
             aims_secret_key: AIMS_TEST_CREDS.secret_key,
-            al_api: process.env.al_api,
+            al_api: AL_API,
             aws_lambda_s3_bucket: S3_BUCKET,
             aws_lambda_zipfile_name: S3_ZIPFILE,
-            azcollect_api: process.env.azcollect_api,
-            ingest_api: process.env.ingest_api 
+            azcollect_api: AZCOLLECT_API,
+            ingest_api: INGEST_API
         } 
     },
     TracingConfig: { Mode: 'PassThrough' },
@@ -303,8 +309,8 @@ const LAMBDA_FUNCTION_CONFIGURATION_CHANGED = {
             al_api: 'new al_api value',
             aws_lambda_s3_bucket: S3_BUCKET,
             aws_lambda_zipfile_name: S3_ZIPFILE,
-            azcollect_api: process.env.azcollect_api,
-            ingest_api: process.env.ingest_api,
+            azcollect_api: AZCOLLECT_API,
+            ingest_api: INGEST_API,
             x: 'XXXX'
         } 
     },
@@ -333,8 +339,8 @@ const LAMBDA_FUNCTION_CONFIGURATION_WITH_STATE = {
                 al_api: 'new al_api value',
                 aws_lambda_s3_bucket: S3_BUCKET,
                 aws_lambda_zipfile_name: S3_ZIPFILE,
-                azcollect_api: process.env.azcollect_api,
-                ingest_api: process.env.ingest_api,
+                azcollect_api: AZCOLLECT_API,
+                ingest_api: INGEST_API,
                 x: 'XXXX'
             } 
         },
@@ -349,6 +355,7 @@ const LAMBDA_FUNCTION_CONFIGURATION_WITH_STATE = {
     };
 
 module.exports = {
+    initProcessEnv : initProcessEnv,
     FUNCTION_ARN : FUNCTION_ARN,
     FUNCTION_NAME : FUNCTION_NAME,
     S3_BUCKET : S3_BUCKET,


### PR DESCRIPTION
### Problem Description
When a collector fails to register during installation we need to register it some time after when Lambda is running

### Solution Description
Align `register()` and `deregister()` interfaces to be async so that they can be called from running Lambda function and not only in CFN temaplate registration resource.
Move to node 12.