### PR TITLE
Register collector during checkin if unregistered

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/al-aws-collector-js",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "license": "MIT",
   "description": "Alert Logic AWS Collector Common Library",
   "repository": {

--- a/test/al_aws_collector_test.js
+++ b/test/al_aws_collector_test.js
@@ -222,6 +222,7 @@ describe('al_aws_collector tests', function() {
                 return callback(null, colMock.CF_DESCRIBE_STACKS_RESPONSE);
             });
             mockLambdaMetricStatistics();
+            colMock.initProcessEnv();
         });
 
         after(function() {
@@ -229,7 +230,7 @@ describe('al_aws_collector tests', function() {
             AWS.restore('CloudWatch', 'getMetricStatistics');
         });
 
-        it('checkin success', function(done) {
+        it('checkin success registered', function(done) {
             var mockCtx = {
                 invokedFunctionArn : colMock.FUNCTION_ARN,
                 functionName : colMock.FUNCTION_NAME,
@@ -241,6 +242,7 @@ describe('al_aws_collector tests', function() {
                     done();
                 }
             };
+            
             AlAwsCollector.load().then(function(creds) {
                 var collector = new AlAwsCollector(
                         mockCtx, 'cwe', AlAwsCollector.IngestTypes.SECMSGS,'1.0.0', creds, undefined, [], []);

--- a/test/collector_mock.js
+++ b/test/collector_mock.js
@@ -122,6 +122,7 @@ const CHECKIN_AZCOLLECT_QUERY = {
         details: [],
         functionName: 'test-VpcFlowCollectLambdaFunction',
         region: 'us-east-1',
+        stackName: 'test-stack-01',
         version: '1.0.0',
         status: 'ok',
         statistics:[
@@ -138,6 +139,7 @@ const CHECKIN_AZCOLLECT_QUERY_CUSTOM_HEALTHCHECK_ERROR = {
         dataType: 'secmsgs',
         functionName: 'test-VpcFlowCollectLambdaFunction',
         region: 'us-east-1',
+        stackName: 'test-stack-01',
         version: '1.0.0',
         status: 'error',
         error_code: 'MYCODE',
@@ -181,6 +183,7 @@ const CHECKIN_ERROR_AZCOLLECT_QUERY = {
         dataType: 'secmsgs',
         functionName: 'test-VpcFlowCollectLambdaFunction',
         region: 'us-east-1',
+        stackName: 'test-stack-01',
         version: '1.0.0',
         status: 'error',
         error_code: 'ALAWS00002',


### PR DESCRIPTION
### Problem Description
Collector id is required for collection to happen.

### Solution Description
Try to reregister collector if `collector_id` is not present in.
Please note that the first registration attempt is happening via registration event coming in from CloudFormation. For all consequent registration attempts this event is not available. It is advised to keep all collector properties required for registration in process env.