### PR TITLE
Fixed Paws collector azcollect update wipes out issue...

### DIFF
--- a/al_aws_collector.js
+++ b/al_aws_collector.js
@@ -310,12 +310,12 @@ class AlAwsCollector {
 
                 if (!azcollect_api || !ingest_api || azcollect_api === "undefined" || ingest_api === "undefined") {
                     // handling errors like this because the other unit tests seem to indicate that
-                    // the collector should register even if there is an error in getting the endpoints.
+                    // the collector should handle check in even if there is an error in getting the endpoints.
                     collector.updateEndpoints((err, newConfig) => {
                         if (err) {
                             console.warn('AWSC0014 Error updating endpoints', err);
                         } else {
-                            // reassign env vars because the config change occurs in the same run in registration.
+                            // reassign env vars because the config change occurs in the same run in handle check in.
                             const {
                                 Environment: {
                                     Variables
@@ -480,7 +480,7 @@ class AlAwsCollector {
                         if (err) {
                             console.warn('AWSC0016 Error updating endpoints', err);
                         } else {
-                            // reassign env vars because the config change occurs in the same run in registration.
+                            // reassign env vars because the config change occurs in the same run in sending status.
                             const {
                                 Environment: {
                                     Variables
@@ -535,7 +535,7 @@ class AlAwsCollector {
                         if (err) {
                             console.warn('AWSC0015 Error updating endpoints', err);
                         } else {
-                            // reassign env vars because the config change occurs in the same run in registration.
+                            // reassign env vars because the config change occurs in the same run in sending data.
                             const {
                                 Environment: {
                                     Variables

--- a/al_aws_collector.js
+++ b/al_aws_collector.js
@@ -117,10 +117,10 @@ class AlAwsCollector {
             process.env.al_data_residency ?
                 process.env.al_data_residency :
                 'default';
-        this._alAzcollectEndpoint = process.env.azollect_api;
+        this._alAzcollectEndpoint = process.env.azcollect_api;
         this._aimsc = new m_alCollector.AimsC(process.env.al_api, aimsCreds, null, null, process.env.customer_id);
         this._endpointsc = new m_alCollector.EndpointsC(process.env.al_api, this._aimsc);
-        this._azcollectc = new m_alCollector.AzcollectC(process.env.azollect_api, this._aimsc, 'aws', collectorType);
+        this._azcollectc = new m_alCollector.AzcollectC(process.env.azcollect_api, this._aimsc, 'aws', collectorType);
         this._ingestc = new m_alCollector.IngestC(process.env.ingest_api, this._aimsc, 'lambda_function');
         this._formatFun = formatFun;
         this._customHealthChecks = healthCheckFuns;
@@ -230,7 +230,7 @@ class AlAwsCollector {
                 } else {
                     var endpoints = {
                         ingest_api : mapResult[0].ingest,
-                        azollect_api : mapResult[1].azcollect
+                        azcollect_api : mapResult[1].azcollect
                     };
                     return m_alAws.setEnv(endpoints, callback);
                 }
@@ -260,7 +260,7 @@ class AlAwsCollector {
                     ingest_api
                 } = process.env;
 
-                if(!azcollect_api || !ingest_api){
+                if(!azcollect_api || !ingest_api || azcollect_api === "undefined" || ingest_api === "undefined"){
                     // handling errors like this because the other unit tests seem to indicate that
                     // the collector should register even if there is an error in getting the endpoints.
                     this.updateEndpoints((err, newConfig) => {
@@ -275,7 +275,7 @@ class AlAwsCollector {
                             } = newConfig;
 
                             Object.assign(process.env, Variables);
-                            this._azcollectc = new m_alCollector.AzcollectC(process.env.azollect_api, this._aimsc, 'aws', this._collectorType);
+                            this._azcollectc = new m_alCollector.AzcollectC(process.env.azcollect_api, this._aimsc, 'aws', this._collectorType);
                             this._ingestc = new m_alCollector.IngestC(process.env.ingest_api, this._aimsc, 'lambda_function');
                         }
 
@@ -308,7 +308,7 @@ class AlAwsCollector {
                     ingest_api
                 } = process.env;
 
-                if (!azcollect_api || !ingest_api) {
+                if (!azcollect_api || !ingest_api || azcollect_api === "undefined" || ingest_api === "undefined") {
                     // handling errors like this because the other unit tests seem to indicate that
                     // the collector should register even if there is an error in getting the endpoints.
                     collector.updateEndpoints((err, newConfig) => {
@@ -323,7 +323,7 @@ class AlAwsCollector {
                             } = newConfig;
 
                             Object.assign(process.env, Variables);
-                            collector._azcollectc = new m_alCollector.AzcollectC(process.env.azollect_api, collector._aimsc, 'aws', collector._collectorType);
+                            collector._azcollectc = new m_alCollector.AzcollectC(process.env.azcollect_api, collector._aimsc, 'aws', collector._collectorType);
                             collector._ingestc = new m_alCollector.IngestC(process.env.ingest_api, collector._aimsc, 'lambda_function');
                         }
 
@@ -473,7 +473,7 @@ class AlAwsCollector {
                     azcollect_api,
                     ingest_api
                 } = process.env;
-                if (!azcollect_api || !ingest_api) {
+                if (!azcollect_api || !ingest_api || azcollect_api === "undefined" || ingest_api === "undefined") {
                     // handling errors like this because the other unit tests seem to indicate that
                     // the collector should send status even if there is an error in getting the endpoints.
                     collector.updateEndpoints((err, newConfig) => {
@@ -487,7 +487,7 @@ class AlAwsCollector {
                                 }
                             } = newConfig;
                             Object.assign(process.env, Variables);
-                            collector._azcollectc = new m_alCollector.AzcollectC(process.env.azollect_api, collector._aimsc, 'aws', collector._collectorType);
+                            collector._azcollectc = new m_alCollector.AzcollectC(process.env.azcollect_api, collector._aimsc, 'aws', collector._collectorType);
                             collector._ingestc = new m_alCollector.IngestC(process.env.ingest_api, collector._aimsc, 'lambda_function');
                         }
                         asyncCallback(null);
@@ -528,7 +528,7 @@ class AlAwsCollector {
                     azcollect_api,
                     ingest_api
                 } = process.env;
-                if (!azcollect_api || !ingest_api) {
+                if (!azcollect_api || !ingest_api || azcollect_api === "undefined" || ingest_api === "undefined") {
                     // handling errors like this because the other unit tests seem to indicate that
                     // the collector should send data even if there is an error in getting the endpoints.
                     collector.updateEndpoints((err, newConfig) => {
@@ -542,7 +542,7 @@ class AlAwsCollector {
                                 }
                             } = newConfig;
                             Object.assign(process.env, Variables);
-                            collector._azcollectc = new m_alCollector.AzcollectC(process.env.azollect_api, collector._aimsc, 'aws', collector._collectorType);
+                            collector._azcollectc = new m_alCollector.AzcollectC(process.env.azcollect_api, collector._aimsc, 'aws', collector._collectorType);
                             collector._ingestc = new m_alCollector.IngestC(process.env.ingest_api, collector._aimsc, 'lambda_function');
                         }
                         asyncCallback(null);

--- a/al_aws_collector.js
+++ b/al_aws_collector.js
@@ -4,7 +4,7 @@
  *
  * Base class for AWS Lambda based collectors.
  *
- * Last message ID: AWSC0013
+ * Last message ID: AWSC0016
  * @end
  * -----------------------------------------------------------------------------
  */
@@ -302,7 +302,38 @@ class AlAwsCollector {
     handleCheckin() {
         var collector = this;
         async.waterfall([
-            function(asyncCallback) {
+            function (asyncCallback) {
+                const {
+                    azcollect_api,
+                    ingest_api
+                } = process.env;
+
+                if (!azcollect_api || !ingest_api) {
+                    // handling errors like this because the other unit tests seem to indicate that
+                    // the collector should register even if there is an error in getting the endpoints.
+                    collector.updateEndpoints((err, newConfig) => {
+                        if (err) {
+                            console.warn('AWSC0014 Error updating endpoints', err);
+                        } else {
+                            // reassign env vars because the config change occurs in the same run in registration.
+                            const {
+                                Environment: {
+                                    Variables
+                                }
+                            } = newConfig;
+
+                            Object.assign(process.env, Variables);
+                            collector._azcollectc = new m_alCollector.AzcollectC(process.env.azollect_api, collector._aimsc, 'aws', collector._collectorType);
+                            collector._ingestc = new m_alCollector.IngestC(process.env.ingest_api, collector._aimsc, 'lambda_function');
+                        }
+
+                        asyncCallback(null);
+                    });
+                } else {
+                    asyncCallback(null);
+                }
+            },
+            function (asyncCallback) {
                 if (!collector.registered) {
                     collector.register(undefined, undefined, (err) => {
                         return asyncCallback(err);
@@ -311,10 +342,10 @@ class AlAwsCollector {
                     return asyncCallback();
                 }
             },
-            function(asyncCallback) {
+            function (asyncCallback) {
                 return collector.checkin(asyncCallback);
             }
-        ], function(err) {
+        ], function (err) {
             return collector.done(err);
         });
     }
@@ -435,44 +466,109 @@ class AlAwsCollector {
 
     sendStatus(status, callback) {
         let collector = this;
-        
-        if(!status || !collector.registered){
-            return callback(null);
-        } else {
-            zlib.deflate(JSON.stringify([status]), (compressionErr, compressed) => {
-                if (compressionErr) {
-                    return callback(compressionErr);
+
+        async.waterfall([
+            (asyncCallback) => {
+                const {
+                    azcollect_api,
+                    ingest_api
+                } = process.env;
+                if (!azcollect_api || !ingest_api) {
+                    // handling errors like this because the other unit tests seem to indicate that
+                    // the collector should send status even if there is an error in getting the endpoints.
+                    collector.updateEndpoints((err, newConfig) => {
+                        if (err) {
+                            console.warn('AWSC0016 Error updating endpoints', err);
+                        } else {
+                            // reassign env vars because the config change occurs in the same run in registration.
+                            const {
+                                Environment: {
+                                    Variables
+                                }
+                            } = newConfig;
+                            Object.assign(process.env, Variables);
+                            collector._azcollectc = new m_alCollector.AzcollectC(process.env.azollect_api, collector._aimsc, 'aws', collector._collectorType);
+                            collector._ingestc = new m_alCollector.IngestC(process.env.ingest_api, collector._aimsc, 'lambda_function');
+                        }
+                        asyncCallback(null);
+                    });
                 } else {
-                    collector._ingestc.sendAgentstatus(compressed)
-                    .then(resp => {
-                        return callback(null, resp);
-                    })
-                    .catch(exception => {
-                        console.warn('AWSC0013 Collector status send failed: ', exception);
-                        return callback(exception);
+                    asyncCallback(null);
+                }
+            },
+            (asyncCallback) => {
+                if (!status || !collector.registered) {
+                    return asyncCallback(null);
+                } else {
+                    zlib.deflate(JSON.stringify([status]), (compressionErr, compressed) => {
+                        if (compressionErr) {
+                            return asyncCallback(compressionErr);
+                        } else {
+                            collector._ingestc.sendAgentstatus(compressed)
+                                .then(resp => {
+                                    return asyncCallback(null, resp);
+                                })
+                                .catch(exception => {
+                                    console.warn('AWSC0013 Collector status send failed: ', exception);
+                                    return asyncCallback(exception);
+                                });
+                        }
                     });
                 }
-            });
-        }
+            }
+        ],
+            callback);
     }
     
     send(data, compress = true, callback) {
         var collector = this;
-        
-        if(!data){
-            return callback(null);
-        }
-        if (compress) {
-            zlib.deflate(data, function(compressionErr, compressed) {
-                if (compressionErr) {
-                    return callback(compressionErr);
+        async.waterfall([
+            (asyncCallback) => {
+                const {
+                    azcollect_api,
+                    ingest_api
+                } = process.env;
+                if (!azcollect_api || !ingest_api) {
+                    // handling errors like this because the other unit tests seem to indicate that
+                    // the collector should send data even if there is an error in getting the endpoints.
+                    collector.updateEndpoints((err, newConfig) => {
+                        if (err) {
+                            console.warn('AWSC0015 Error updating endpoints', err);
+                        } else {
+                            // reassign env vars because the config change occurs in the same run in registration.
+                            const {
+                                Environment: {
+                                    Variables
+                                }
+                            } = newConfig;
+                            Object.assign(process.env, Variables);
+                            collector._azcollectc = new m_alCollector.AzcollectC(process.env.azollect_api, collector._aimsc, 'aws', collector._collectorType);
+                            collector._ingestc = new m_alCollector.IngestC(process.env.ingest_api, collector._aimsc, 'lambda_function');
+                        }
+                        asyncCallback(null);
+                    });
                 } else {
-                    return collector._send(compressed, callback);
+                    asyncCallback(null);
                 }
-            });
-        } else {
-            return collector._send(data, callback);
-        }
+            },
+            (asyncCallback) => {
+                if (!data) {
+                    return asyncCallback(null);
+                }
+                if (compress) {
+                    zlib.deflate(data, function (compressionErr, compressed) {
+                        if (compressionErr) {
+                            return asyncCallback(compressionErr);
+                        } else {
+                            return collector._send(compressed, asyncCallback);
+                        }
+                    });
+                } else {
+                    return collector._send(data, asyncCallback);
+                }
+            }
+        ],
+            callback);
     }
     
     _send(data, callback) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/al-aws-collector-js",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "license": "MIT",
   "description": "Alert Logic AWS Collector Common Library",
   "repository": {


### PR DESCRIPTION
Right now, updating a collevtor wipes out the azcollect and ingest endpoints. We need to have the collector repopulate these values if these have been wiped out.

what we need for the collector to check if the ingest api and azcollect api is present beofre attempting checking or ingest sends
