### PR TITLE
Bump al-collector-js dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/al-aws-collector-js",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "license": "MIT",
   "description": "Alert Logic AWS Collector Common Library",
   "repository": {
@@ -32,7 +32,7 @@
     "sinon": "^7.5.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "2.0.0",
+    "@alertlogic/al-collector-js": "2.0.2",
     "cfn-response": "1.0.1",
     "async": "3.0.1",
     "moment": "2.24.0",


### PR DESCRIPTION
### Solution Description
- bump al-collector-js dependency to catch unlink errors with cache: https://github.com/alertlogic/al-collector-js/pull/43


