### PR TITLE
ENG-17586 [paws-collectors] Stream specific status reporting

### DIFF
--- a/al_aws_collector.js
+++ b/al_aws_collector.js
@@ -159,7 +159,7 @@ class AlAwsCollector {
         return this._collectorId;
     }
     
-    done(error) {
+    done(error, streamType) {
         let context = this._invokeContext;
         if (error) {
             // The lambda context tries to stringify errors, 
@@ -175,7 +175,7 @@ class AlAwsCollector {
                         // when all else fails, stringify it the gross way with inspect
                         util.inspect(error);
             }
-            const status = this.prepareErrorStatus(errorString);
+            const status = streamType ? this.prepareErrorStatus(errorString, streamType, null) : this.prepareErrorStatus(errorString);
             this.sendStatus(status, () => {
                 context.fail(errorString);
             });
@@ -184,7 +184,7 @@ class AlAwsCollector {
         }
     }
     
-    prepareErrorStatus(errorString, streamName = 'none', collectionType, errorCode) {
+    prepareErrorStatus(errorString, collectionType, errorCode, streamName = 'none') {
         let cType = collectionType ? collectionType : this._ingestType;
         let errorData = errorCode ? 
             [
@@ -202,7 +202,7 @@ class AlAwsCollector {
             host_uuid: this._collectorId,
             data: errorData,
             agent_type: this._collectorType,
-            collection_type: cType,
+            collection_type: cType, //ingest will treat it as application in assets
             timestamp: moment().unix()
         };
     }

--- a/al_aws_collector.js
+++ b/al_aws_collector.js
@@ -193,7 +193,7 @@ class AlAwsCollector {
             return context.succeed();
         }
     }
-    prepareHealthyStatus(collectionType, streamName = 'none') {
+    prepareHealthyStatus(streamName = 'none', collectionType) {
         return {
             stream_name: streamName,
             status_type: 'ok',
@@ -413,7 +413,7 @@ class AlAwsCollector {
                 let streamSpecificStatus = [];
                 if (Array.isArray(collectorStreams) && collectorStreams.length > 0) {
                     collectorStreams.map(streamType => {
-                        let okStatus = collector.prepareHealthyStatus(`${collector._applicationId}_${streamType}`);
+                        let okStatus = collector.prepareHealthyStatus('none', `${collector._applicationId}_${streamType}`);
                         streamSpecificStatus.push(okStatus);
                     });
                 } else {

--- a/al_aws_collector.js
+++ b/al_aws_collector.js
@@ -185,7 +185,7 @@ class AlAwsCollector {
                         util.inspect(error);
             }
             // post stream specific error
-            const status = streamType ? this.prepareErrorStatus(errorString,'none' , streamType) : this.prepareErrorStatus(errorString);
+            const status = streamType ? this.prepareErrorStatus(errorString, 'none', streamType) : this.prepareErrorStatus(errorString);
             this.sendStatus(status, () => {
                 context.fail(errorString);
             });
@@ -193,7 +193,7 @@ class AlAwsCollector {
             return context.succeed();
         }
     }
-    prepareHealthyStatus(streamType, streamName = 'none') {
+    prepareHealthyStatus(collectionType, streamName = 'none') {
         return {
             stream_name: streamName,
             status_type: 'ok',
@@ -202,7 +202,7 @@ class AlAwsCollector {
             host_uuid: this._collectorId,
             data: [],
             agent_type: this._collectorType,
-            collection_type:  streamType ? streamType : this._ingestType,
+            collection_type: collectionType ? collectionType : this._ingestType,
             timestamp: moment().unix()
         };
     }

--- a/al_aws_collector.js
+++ b/al_aws_collector.js
@@ -406,7 +406,7 @@ class AlAwsCollector {
             let invocationStatsDatapoints = checkinParts[1].statistics[0].Datapoints ? checkinParts[1].statistics[0].Datapoints : checkinParts[1].statistics;
             let errorStatsDatapoints = checkinParts[1].statistics[1].Datapoints ? checkinParts[1].statistics[1].Datapoints : checkinParts[1].statistics ;
 
-            if (checkinParts[0].status === 'ok'  && invocationStatsDatapoints.length > 0 
+            if (checkinParts[0].status === 'ok'  && invocationStatsDatapoints.length > 0  && invocationStatsDatapoints[0].Sum > 0
                  && errorStatsDatapoints.length > 0 && errorStatsDatapoints[0].Sum === 0) {
                 let collectorStreams = JSON.parse(collector._streams);
                 if (Array.isArray(collectorStreams) && collectorStreams.length > 0) {

--- a/al_aws_collector.js
+++ b/al_aws_collector.js
@@ -403,12 +403,11 @@ class AlAwsCollector {
         ],
         function(err, checkinParts) {
 
-            let invocationStatsDatapoints = checkinParts[1].statistics[0].Datapoints ? checkinParts[1].statistics[0].Datapoints : checkinParts[1].statistics;
-            let errorStatsDatapoints = checkinParts[1].statistics[1].Datapoints ? checkinParts[1].statistics[1].Datapoints : checkinParts[1].statistics ;
-
+            const invocationStatsDatapoints = checkinParts[1].statistics[0].Datapoints ? checkinParts[1].statistics[0].Datapoints : checkinParts[1].statistics;
+            const errorStatsDatapoints = checkinParts[1].statistics[1].Datapoints ? checkinParts[1].statistics[1].Datapoints : checkinParts[1].statistics ;
+            const collectorStreams = collector._streams;
             if (checkinParts[0].status === 'ok'  && invocationStatsDatapoints.length > 0  && invocationStatsDatapoints[0].Sum > 0
                  && errorStatsDatapoints.length > 0 && errorStatsDatapoints[0].Sum === 0) {
-                let collectorStreams = JSON.parse(collector._streams);
                 if (Array.isArray(collectorStreams) && collectorStreams.length > 0) {
                     collectorStreams.map(streamType => {
                         // make api call to send status ok

--- a/al_aws_collector.js
+++ b/al_aws_collector.js
@@ -180,10 +180,15 @@ class AlAwsCollector {
                 context.fail(errorString);
             });
         } else {
-            let okStatus = prepareHealthyStatus(streamType);
-            this.sendStatus(okStatus, () => {
+            let okStatus = this.prepareHealthyStatus(streamType);
+            if (moment().minutes() === 0 && moment().seconds() === 0) {
+                // post the sub object status on hourly basis
+                this.sendStatus(okStatus, () => {
+                    return context.succeed();
+                });
+            } else {
                 return context.succeed();
-            });
+            }
         }
     }
 

--- a/al_aws_collector.js
+++ b/al_aws_collector.js
@@ -180,8 +180,25 @@ class AlAwsCollector {
                 context.fail(errorString);
             });
         } else {
-            return context.succeed();
+            let okStatus = prepareHealthyStatus(streamType);
+            this.sendStatus(okStatus, () => {
+                return context.succeed();
+            });
         }
+    }
+
+    prepareHealthyStatus(streamType, streamName = 'none') {
+        return {
+            stream_name: streamName,
+            status_type: 'ok',
+            stream_type: 'status',
+            message_type: 'collector_status',
+            host_uuid: this._collectorId,
+            data: [],
+            agent_type: this._collectorType,
+            collection_type:  streamType ? streamType : this._ingestType,
+            timestamp: moment().unix()
+        };
     }
     
     prepareErrorStatus(errorString, collectionType, errorCode, streamName = 'none') {
@@ -202,7 +219,7 @@ class AlAwsCollector {
             host_uuid: this._collectorId,
             data: errorData,
             agent_type: this._collectorType,
-            collection_type: cType, //ingest will treat it as application in assets
+            collection_type: cType,
             timestamp: moment().unix()
         };
     }

--- a/al_aws_collector.js
+++ b/al_aws_collector.js
@@ -80,7 +80,7 @@ function getDecryptedCredentials(callback) {
  * @param {function} formatFun - callback formatting function
  * @param {Array.<function>} healthCheckFuns - list of custom health check functions (can be just empty, so only common are applied)
  * @param {Array.<function>} statsFuns - list of custom stats functions (can be just empty, so only common are applied)
- *
+ * @param {Array} streams - List of stream from collector
  */
 class AlAwsCollector {
     static get IngestTypes() {

--- a/al_aws_collector.js
+++ b/al_aws_collector.js
@@ -185,7 +185,7 @@ class AlAwsCollector {
                         util.inspect(error);
             }
             // post stream specific error
-            const status = streamType ? this.prepareErrorStatus(errorString, streamType, null) : this.prepareErrorStatus(errorString);
+            const status = streamType ? this.prepareErrorStatus(errorString,'none' , streamType) : this.prepareErrorStatus(errorString);
             this.sendStatus(status, () => {
                 context.fail(errorString);
             });
@@ -207,7 +207,7 @@ class AlAwsCollector {
         };
     }
     
-    prepareErrorStatus(errorString, collectionType, errorCode, streamName = 'none') {
+    prepareErrorStatus(errorString, streamName = 'none', collectionType, errorCode) {
         let cType = collectionType ? collectionType : this._ingestType;
         let errorData = errorCode ? 
             [
@@ -403,11 +403,11 @@ class AlAwsCollector {
         ],
         function(err, checkinParts) {
 
-            let invocationStatsDatapoints = checkinParts[1].statistics[0].Datapoints;
-            let errorStatsDatapoints = checkinParts[1].statistics[1].Datapoints ;
+            let invocationStatsDatapoints = checkinParts[1].statistics[0].Datapoints ? checkinParts[1].statistics[0].Datapoints : checkinParts[1].statistics;
+            let errorStatsDatapoints = checkinParts[1].statistics[1].Datapoints ? checkinParts[1].statistics[1].Datapoints : checkinParts[1].statistics ;
 
-            if (checkinParts[0].status === 'ok' &&  invocationStatsDatapoints && invocationStatsDatapoints.length > 0 &&  errorStatsDatapoints && errorStatsDatapoints.length > 0 && errorStatsDatapoints[0].Sum === 0) {
-                
+            if (checkinParts[0].status === 'ok'  && invocationStatsDatapoints.length > 0 
+                 && errorStatsDatapoints.length > 0 && errorStatsDatapoints[0].Sum === 0) {
                 let collectorStreams = JSON.parse(collector._streams);
                 if (Array.isArray(collectorStreams) && collectorStreams.length > 0) {
                     collectorStreams.map(streamType => {
@@ -420,8 +420,8 @@ class AlAwsCollector {
                 } else {
                     let okStatus = collector.prepareHealthyStatus();
                     collector.sendStatus(okStatus, () => {
-                            return context.succeed();
-                        });
+                        return context.succeed();
+                    });
                 }
             }
             const checkin = Object.assign(

--- a/al_aws_collector.js
+++ b/al_aws_collector.js
@@ -44,6 +44,8 @@ const NOUPDATE_CONFIG_PARAMS = [
     'LastUpdateStatusReasonCode'
 ];
 
+const  SUB_OBJECT_STATE_TABLE_NAME = 'CollectorSubObjectState';
+
 function getDecryptedCredentials(callback) {
     if (AIMS_DECRYPTED_CREDS) {
         return callback(null, AIMS_DECRYPTED_CREDS);
@@ -197,6 +199,8 @@ class AlAwsCollector {
                         this.sendStatus(okStatus, () => {
                             return context.succeed();
                         });
+                    } else {
+                        return context.succeed();
                     }
                 });
             } else {
@@ -245,14 +249,13 @@ class AlAwsCollector {
     checkCollectorSubObjectState(error, streamType, callback) {
         const collector = this;
         const DDB = new AWS.DynamoDB();
-        const TABLE_NAME = 'CollectorSubObjectState';
         const ERROR = 'ERROR';
         const params = {
             Key: {
                 "CollectorId": { S: collector._collectorId },
                 "StreamType": { S: streamType }
             },
-            TableName: TABLE_NAME,
+            TableName: SUB_OBJECT_STATE_TABLE_NAME,
             ConsistentRead: true
         }
         const getItemPromise = DDB.getItem(params).promise();
@@ -270,7 +273,7 @@ class AlAwsCollector {
                             Status: { S: ERROR },
                             TimeStamp: { N: moment().unix().toString() }
                         },
-                        TableName: TABLE_NAME
+                        TableName: SUB_OBJECT_STATE_TABLE_NAME
                     }
                     DDB.putItem(newRecord, (err) => {
                         if (err) {
@@ -303,7 +306,6 @@ class AlAwsCollector {
     updateSubObjectStateDBEntry(streamType, Status, callback) {
         const collector = this;
         const DDB = new AWS.DynamoDB();
-        const TABLE_NAME = 'CollectorSubObjectState'
 
         const updateParams = {
             Key: {
@@ -320,7 +322,7 @@ class AlAwsCollector {
                     Value: { N: moment().unix().toString() }
                 }
             },
-            TableName: TABLE_NAME
+            TableName: SUB_OBJECT_STATE_TABLE_NAME
         };
         DDB.updateItem(updateParams, (err) => {
             if (err) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/al-aws-collector-js",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "license": "MIT",
   "description": "Alert Logic AWS Collector Common Library",
   "repository": {

--- a/test/al_aws_collector_test.js
+++ b/test/al_aws_collector_test.js
@@ -746,6 +746,36 @@ describe('al_aws_collector tests', function() {
             collector.done(stringifialbleError);
         });
 
+        it('calls success when there is no error and stremtype is passed', (done) => {
+            const stringifialbleError = {
+                foo: "bar"
+            };
+           const testContext = {
+               invokedFunctionArn: colMock.FUNCTION_ARN,
+               succeed: () => true,
+               fail: (error) => {
+                assert.equal(error, JSON.stringify(stringifialbleError));
+                done();
+            }
+           };
+
+           collector = new AlAwsCollector(
+               testContext,
+               'cwe',
+               AlAwsCollector.IngestTypes.SECMSGS,
+               '1.0.0',
+               colMock.AIMS_TEST_CREDS
+           );
+           let spy = sinon.spy(collector, "sendStatus");
+           let promise = new Promise(function (resolve, reject) {
+               return resolve(collector.done(stringifialbleError, 'salesforce_EventLogFile'));
+           });
+
+           promise.then((result) => {
+               sinon.assert.calledOnce(spy);
+           });
+       });
+
         it('returns errors that can be stringified in their raw state with env vars not set', (done) => {
             const envIngestApi = process.env.ingest_api;
             const envAzcollectApi = process.env.ingest_api;

--- a/test/al_aws_collector_test.js
+++ b/test/al_aws_collector_test.js
@@ -362,8 +362,8 @@ describe('al_aws_collector tests', function() {
                     return resolve(collector.handleEvent(testEvent));
                 });
                 promise.then((result) => {
-                    sinon.assert.calledOnce(prepareHealthyStatusSpy,0);
-                    sinon.assert.calledOnce(sendStatusSpy,0);
+                    sinon.assert.notCalled(prepareHealthyStatusSpy);
+                    sinon.assert.notCalled(sendStatusSpy);
                 });
             });
         });
@@ -1182,7 +1182,7 @@ describe('al_aws_collector error tests', function() {
     it('checkin error', function(done) {
         AlAwsCollector.load().then(function(creds) {
             var collector = new AlAwsCollector(
-                context, 'cwe', AlAwsCollector.IngestTypes.SECMSGS,'1.0.0', creds, undefined, [], [],[]);
+                context, 'cwe', AlAwsCollector.IngestTypes.SECMSGS,'1.0.0', creds, undefined, [], []);
             collector.checkin(function(error) {
                 assert.equal(error, 'post error');
                 done();

--- a/test/al_aws_collector_test.js
+++ b/test/al_aws_collector_test.js
@@ -147,6 +147,18 @@ var formatFun = function (event, context, callback) {
     return callback(null, event);
 };
 
+function mockDDB(getItemStub, putItemStub, updateItemStub){
+    const defaultMock = (_params, callback) => {
+        return callback(null, {data: null});
+    };
+
+    AWS.mock('DynamoDB', 'getItem', getItemStub ? getItemStub : defaultMock);
+
+    AWS.mock('DynamoDB', 'putItem', putItemStub ? putItemStub : defaultMock);
+
+    AWS.mock('DynamoDB', 'updateItem', updateItemStub ? updateItemStub : defaultMock);
+}
+
 describe('al_aws_collector tests', function() {
 
     beforeEach(function(){
@@ -719,6 +731,32 @@ describe('al_aws_collector tests', function() {
             assert.ok(doneResult);
         });
 
+        it('calls success when there is no error and stremtype is passed', (done) => {
+             process.env.AWS_REGION = 'ap-south-1';
+            const testContext = {
+                invokedFunctionArn: colMock.FUNCTION_ARN,
+                succeed: () => true,
+                fail: () => false
+            };
+
+            collector = new AlAwsCollector(
+                testContext,
+                'cwe',
+                AlAwsCollector.IngestTypes.SECMSGS,
+                '1.0.0',
+                colMock.AIMS_TEST_CREDS
+            );
+            let spy = sinon.spy(collector, "checkCollectorSubObjectState");
+            let promise = new Promise(function (resolve, reject) {
+                return resolve(collector.done(null, 'salesforce_EventLogFile'));
+            });
+
+            promise.then((result) => {
+                sinon.assert.calledOnce(spy);
+                done();
+            });
+        });
+
         it('returns errors that can be stringified in their raw state', (done) => {
             const stringifialbleError = {
                 foo: "bar"
@@ -979,6 +1017,51 @@ describe('al_aws_collector tests', function() {
             done();
         });
     });
+
+    describe('checkCollectorSubObjectState ', function(){
+      
+        it('creates a new DDB item when the error occure with stream type', (done)=>{
+            const fakeFun = function(_params, callback){return callback(null, {data:null});};
+            const putItemStub = sinon.stub().callsFake(fakeFun);
+            const updateItemStub = sinon.stub().callsFake(fakeFun);
+            mockDDB(null, putItemStub, updateItemStub);
+            const stringifialbleError = {
+                foo: "bar"
+            };
+            
+            let testContext = {
+                invokedFunctionArn: colMock.FUNCTION_ARN,
+                fail : () => false,
+                succeed : function() {
+                   const putItemArgs = putItemStub.args[0][0];
+                   const updateItemArgs = updateItemStub.args[0][0];
+                    assert.equal(putItemStub.called, true, 'should put a new item in');
+                    assert.equal(putItemArgs.Item.StreamType.S, "salesforce_EventLogFile");
+                    assert.equal(updateItemArgs.Item.StreamType.S, "salesforce_EventLogFile");
+
+                    AWS.restore('DynamoDB');
+                    done();
+                }
+            };
+            
+            AlAwsCollector.load().then(function(creds) {
+                var collector = new AlAwsCollector(testContext,'cwe',AlAwsCollector.IngestTypes.LOGMSGS,'1.0.0',colMock.AIMS_TEST_CREDS);
+                let prepareErrorStatusSpy = sinon.spy(collector,'prepareErrorStatus');
+                let sendStatusSpy = sinon.spy(collector,'sendStatus');
+                let promise = new Promise(function (resolve, reject) {
+                    return resolve(collector.done(stringifialbleError, 'salesforce_EventLogFile'));
+                });
+    
+                promise.then((result) => {
+                    sinon.assert.calledOnce(prepareErrorStatusSpy);
+                    sinon.assert.calledOnce(sendStatusSpy);
+                    done();
+                });
+            });
+        });
+        
+    });
+
 });
 
 


### PR DESCRIPTION
### Stream specific status reporting
As of now whenever collector faces some issues/error we passing through callback(err) which internally reporting to **ingest api** `/data/agentstatus `marking stream as "status". This works fine if collector collecting single object.
In case of PAWS collectors, there are several collectors e.g Salesforce, GSuite which are kind of collecting different Log objects.
Failure to collect single log object will report the error & collector status as not healthy but if subsequently next log object collects the log then previous status will be overridden.

### Solution
Based on how s3 collector utilizing streams to have seperate status for each message type I come with streamType attribute.
While reporting error we should pass the `LogObject` for which its failing as `streamType` so it will have multiple status & eventually appropriate status.
e.g. This is ref from s3collector.
```
"statuses": {
                    "s3_master_status": {
                        "type": "s3",
                        "timestamp": 1605222207168,
                        "stream": "status",
                        "reasons": [],
                        "metadata": [],
                        "condition": "ok",
                        "application": "master"
                    },
                    "s3_logmsgs_status": {
                        "type": "s3",
                        "timestamp": 1605708631235,
                        "stream": "status",
                        "reasons": [],
                        "metadata": [],
                        "condition": "offline",
                        "application": "logmsgs"
                    },
                    "s3_client_status": {
                        "type": "s3",
                        "timestamp": 1605222206163,
                        "stream": "status",
                        "reasons": [],
                        "metadata": [],
                        "condition": "ok",
                        "application": "client"
                    },
                    "paws_s3_status": {
                        "type": "paws",
                        "timestamp": 1605216096,
                        "stream": "status",
                        "reasons": [],
                        "metadata": [],
                        "condition": "offline",
                        "application": "s3"
                    }
                },
```
And appropriately I have done changes in library so e.g Salesforce will have statues like
```
{
    "statuses": {
        "paws_LoginHistory_status": {
            "type": "paws",
            "timestamp": 1606287737946,
            "stream": "status",
            "reasons": {
                "none": {
                    "text": "\"Login History error\""
                }
            },
            "metadata": [],
            "condition": "error",
            "application": "LoginHistory"
        },
        "paws_LoginEvent_status": {
            "type": "paws",
            "timestamp": 1606287967034,
            "stream": "status",
            "reasons": {
                "none": {
                    "text": "\"Login Event error\""
                }
            },
            "metadata": [],
            "condition": "error",
            "application": "LoginEvent"
        },
        "paws_EventLogFile_status": {
            "type": "paws",
            "timestamp": 1606287798993,
            "stream": "status",
            "reasons": {
                "none": {
                    "text": "\"State is currently being processed by another invocation\""
                }
            },
            "metadata": [],
            "condition": "error",
            "application": "EventLogFile"
        },
        "paws_ApiEvent_status": {
            "type": "paws",
            "timestamp": 1606287911102,
            "stream": "status",
            "reasons": {
                "none": {
                    "text": "\"Api Event error\""
                }
            },
            "metadata": [],
            "condition": "error",
            "application": "ApiEvent"
        }
    },
    "status": "error"
}
```

