### PR TITLE
Added handleEventAsync method to handle async event

### DIFF
--- a/al_aws_collector.js
+++ b/al_aws_collector.js
@@ -796,6 +796,21 @@ class AlAwsCollector {
         }
     }
     
+    /**
+     * To handle async event 
+     * @param {*} event 
+     */
+    handleEventAsync(event) {
+        return new Promise((resolve, reject) => {
+            this.handleEvent(event, (err, data) => {
+                if (err) {
+                    reject(err);
+                } else {
+                    resolve(data);
+                }
+            })
+        });
+    }
     _applyConfigChanges(newValues, config, callback) {
         var newConfig = {};
         Object.assign(newConfig, config);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/al-aws-collector-js",
-  "version": "3.0.9",
+  "version": "3.0.10",
   "license": "MIT",
   "description": "Alert Logic AWS Collector Common Library",
   "repository": {


### PR DESCRIPTION
### Problem
S3 collector datadog handle cause  lambda timeout issue . To handle that i have return the value from s3 handler and so the deployment of s3 collect break at RegistrationResource step as it's not waiting to complete the Azcollect registration service call.

### Solution
Wrap the handleEvent method with promise  to handle async event and resolve once handlerEvent method completed .


