### PR TITLE
[Do not merge ] ENG-25186 : Send the lmc stats to ingest when ingest type is logmsgs

### DIFF
--- a/al_aws_collector.js
+++ b/al_aws_collector.js
@@ -705,7 +705,7 @@ class AlAwsCollector {
         callback);
     }
     
-    processLog(messages, formatFun, hostmetaElems, ingestType = '', callback) {
+    processLog(messages, formatFun, hostmetaElems, callback) {
         if(arguments.length === 3 && typeof hostmetaElems === 'function'){
             callback = hostmetaElems;
             hostmetaElems = this._defaultHostmetaElems();
@@ -719,16 +719,13 @@ class AlAwsCollector {
                     return callback(err);
                 } else {
                     // send the lmc stats if ingest type is logmsgs
-                    collector.send(payload, false, ingestType, (err, res) => {
+                    collector.send(payload, false, AlAwsCollector.IngestTypes.LOGMSGS, (err, res) => {
                         if (err) {
                             return callback(err);
                         }
                         else {
-                            if (collector._ingestType == AlAwsCollector.IngestTypes.LOGMSGS) {
-                                const stats = collector.prepareLmcStats(messages.length, payload.byteLength);
-                                return collector.send(JSON.stringify([stats]), true, 'lmcstats', callback);
-                            }
-                            else return callback(null, res);
+                            const stats = collector.prepareLmcStats(messages.length, JSON.stringify(messages).length);
+                            return collector.send(JSON.stringify([stats]), true, AlAwsCollector.IngestTypes.LMCSTATS, callback);
                         }
                     });
                 }

--- a/al_aws_collector.js
+++ b/al_aws_collector.js
@@ -725,7 +725,7 @@ class AlAwsCollector {
             appliance_id: '',
             source_type: this._collectorType,
             source_id: this._collectorId,
-            host_uuid: this._collectorId,
+            host_id: this._collectorId,
             event_count: event_count,
             byte_count: byte_count,
             timestamp: moment().unix()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/al-aws-collector-js",
-  "version": "3.0.10",
+  "version": "3.0.11",
   "license": "MIT",
   "description": "Alert Logic AWS Collector Common Library",
   "repository": {
@@ -32,7 +32,7 @@
     "sinon": "^7.5.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "2.0.2",
+    "@alertlogic/al-collector-js": "2.0.3",
     "cfn-response": "1.0.1",
     "async": "3.0.1",
     "moment": "2.24.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "sinon": "^7.5.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "2.0.3",
+    "@alertlogic/al-collector-js": "2.0.4",
     "cfn-response": "1.0.1",
     "async": "3.0.1",
     "moment": "2.24.0",

--- a/test/al_aws_collector_test.js
+++ b/test/al_aws_collector_test.js
@@ -147,6 +147,20 @@ var formatFun = function (event, context, callback) {
     return callback(null, event);
 };
 
+var parseLogmsgsFun = function(m) {
+    let messagePayload = {
+      messageTs: 1542138053,
+      priority: 11,
+      progName: 'o365webhook',
+      pid: undefined,
+      message: m,
+      messageType: 'json/azure.o365',
+      messageTypeId: 'AzureActiveDirectory',
+      messageTsUs: undefined
+    };
+    
+    return messagePayload;
+};
 
 describe('al_aws_collector tests', function() {
 
@@ -637,6 +651,19 @@ describe('al_aws_collector tests', function() {
                         sinon.assert.calledWith(ingestCLmcStatsStub, compressed);
                         done();
                     });
+                });
+            });
+        });
+
+        it('processLog send the logmsgs and lmcstats successfully', function () {
+            AlAwsCollector.load().then(function (creds) {
+                var collector = new AlAwsCollector(
+                    context, 'paws', AlAwsCollector.IngestTypes.LOGMSGS, '1.0.0', creds);
+                var data = 'some-data';
+                collector.processLog(data, parseLogmsgsFun, null,  (error) =>{
+                    assert.ifError(error);
+                    sinon.assert.calledOnce(ingestCLogmsgsStub);
+                    sinon.assert.calledOnce(ingestCLmcStatsStub);
                 });
             });
         });


### PR DESCRIPTION
Send the lmc stats to ingest by calling sendLmcstats method from al-collector-js [pr](https://github.com/alertlogic/al-collector-js/pull/44/files)  when ingest type is logmsgs.


