### PR TITLE
Allow to send  multiple ingest type

### DIFF
--- a/al_aws_collector.js
+++ b/al_aws_collector.js
@@ -87,7 +87,8 @@ class AlAwsCollector {
         return {
             SECMSGS : 'secmsgs',
             VPCFLOW : 'vpcflow',
-            LOGMSGS : 'logmsgs'
+            LOGMSGS : 'logmsgs',
+            LMCSTATS: 'lmcstats'
         }
     };
     
@@ -576,7 +577,7 @@ class AlAwsCollector {
             callback);
     }
     
-    send(data, compress = true, callback) {
+    send(data, compress = true, ingestType, callback) {
         var collector = this;
         async.waterfall([
             (asyncCallback) => {
@@ -616,20 +617,20 @@ class AlAwsCollector {
                         if (compressionErr) {
                             return asyncCallback(compressionErr);
                         } else {
-                            return collector._send(compressed, asyncCallback);
+                            return collector._send(compressed, ingestType, asyncCallback);
                         }
                     });
                 } else {
-                    return collector._send(data, asyncCallback);
+                    return collector._send(data, ingestType, asyncCallback);
                 }
             }
         ],
             callback);
     }
     
-    _send(data, callback) {
+    _send(data, ingestType, callback) {
         var collector = this;
-        var ingestType = collector._ingestType;
+        var ingestType = ingestType ? ingestType : collector._ingestType;
         switch (ingestType) {
             case AlAwsCollector.IngestTypes.SECMSGS:
                 collector._ingestc.sendSecmsgs(data)
@@ -658,6 +659,15 @@ class AlAwsCollector {
                     return callback(exception);
                 });
                 break;
+            case AlAwsCollector.IngestTypes.LMCSTATS:
+                collector._ingestc.sendLmcstats(data)
+                .then(resp => {
+                    return callback(null, resp);
+                })
+                .catch(exception => {
+                    return callback(exception);
+                });
+                break;
             default:
                 return callback(`AWSC0005 Unknown Alertlogic ingestion type: ${ingestType}`);
         }
@@ -675,13 +685,13 @@ class AlAwsCollector {
                     asyncCallback = compress;
                     compress = true;
                 } 
-                collector.send(formattedData, compress, asyncCallback);
+                collector.send(formattedData, compress, collector._ingestType, asyncCallback);
             }
         ],
         callback);
     }
     
-    processLog(messages, formatFun, hostmetaElems, callback) {
+    processLog(messages, formatFun, hostmetaElems, injestType = '', callback) {
         if(arguments.length === 3 && typeof hostmetaElems === 'function'){
             callback = hostmetaElems;
             hostmetaElems = this._defaultHostmetaElems();
@@ -694,7 +704,7 @@ class AlAwsCollector {
                 if (err) {
                     return callback(err);
                 } else {
-                    return collector.send(payload, false, callback);
+                    return collector.send(payload, false, injestType,  callback);
                 }
             });
         } else {

--- a/al_aws_collector.js
+++ b/al_aws_collector.js
@@ -691,7 +691,7 @@ class AlAwsCollector {
         callback);
     }
     
-    processLog(messages, formatFun, hostmetaElems, injestType = '', callback) {
+    processLog(messages, formatFun, hostmetaElems, ingestType = '', callback) {
         if(arguments.length === 3 && typeof hostmetaElems === 'function'){
             callback = hostmetaElems;
             hostmetaElems = this._defaultHostmetaElems();
@@ -704,7 +704,7 @@ class AlAwsCollector {
                 if (err) {
                     return callback(err);
                 } else {
-                    return collector.send(payload, false, injestType,  callback);
+                    return collector.send(payload, false, ingestType,  callback);
                 }
             });
         } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/al-aws-collector-js",
-  "version": "3.0.10",
+  "version": "4.0.0",
   "license": "MIT",
   "description": "Alert Logic AWS Collector Common Library",
   "repository": {
@@ -32,7 +32,7 @@
     "sinon": "^7.5.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "2.0.2",
+    "@alertlogic/al-collector-js": "2.0.3",
     "cfn-response": "1.0.1",
     "async": "3.0.1",
     "moment": "2.24.0",

--- a/test/al_aws_collector_test.js
+++ b/test/al_aws_collector_test.js
@@ -646,7 +646,7 @@ describe('al_aws_collector tests', function() {
         var sendStub;
         before(function() {
             sendStub = sinon.stub(AlAwsCollector.prototype, 'send').callsFake(
-                function fakeFn(data, compress,ingestType,callback) {
+                function fakeFn(data, compress, ingestType, callback) {
                     return callback(null, null);
                 });
         });

--- a/test/al_aws_collector_test.js
+++ b/test/al_aws_collector_test.js
@@ -489,6 +489,7 @@ describe('al_aws_collector tests', function() {
         var ingestCVpcFlowStub;
         var ingestCLogmsgsStub;
         var ingestCAgentstatusStub;
+        var ingestCLmcStatsStub;
         
         beforeEach(function() {
             ingestCSecmsgsStub = sinon.stub(m_alCollector.IngestC.prototype, 'sendSecmsgs').callsFake(
@@ -518,6 +519,13 @@ describe('al_aws_collector tests', function() {
                             resolve(null);
                         });
                     });
+
+            ingestCLmcStatsStub = sinon.stub(m_alCollector.IngestC.prototype, 'sendLmcstats').callsFake(
+                function fakeFn(data, callback) {
+                    return new Promise(function (resolve, reject) {
+                        resolve(null);
+                    });
+                });
         });
         
         afterEach(function() {
@@ -525,6 +533,7 @@ describe('al_aws_collector tests', function() {
             ingestCVpcFlowStub.restore();
             ingestCLogmsgsStub.restore();
             ingestCAgentstatusStub.restore();
+            ingestCLmcStatsStub.restore();
         });
 
         it('dont send if data is falsey', function(done) {
@@ -532,7 +541,7 @@ describe('al_aws_collector tests', function() {
                 var collector = new AlAwsCollector(
                     context, 'cwe', AlAwsCollector.IngestTypes.SECMSGS, '1.0.0', creds);
                 var data = '';
-                collector.send(data, true, function(error) {
+                collector.send(data, true, AlAwsCollector.IngestTypes.SECMSGS, function(error) {
                     assert.ifError(error);
                     sinon.assert.notCalled(ingestCSecmsgsStub);
                     done();
@@ -545,7 +554,7 @@ describe('al_aws_collector tests', function() {
                 var collector = new AlAwsCollector(
                     context, 'cwe', AlAwsCollector.IngestTypes.SECMSGS, '1.0.0', creds);
                 var data = 'some-data';
-                collector.send(data, true, function(error) {
+                collector.send(data, true,AlAwsCollector.IngestTypes.SECMSGS, function(error) {
                     assert.ifError(error);
                     sinon.assert.calledOnce(ingestCSecmsgsStub);
                     zlib.deflate(data, function(compressionErr, compressed) {
@@ -562,7 +571,7 @@ describe('al_aws_collector tests', function() {
                 var collector = new AlAwsCollector(
                     context, 'paws', AlAwsCollector.IngestTypes.LOGMSGS, '1.0.0', creds);
                 var data = 'some-data';
-                collector.send(data, false, function(error) {
+                collector.send(data, false, '', function(error) {
                     assert.ifError(error);
                     sinon.assert.calledOnce(ingestCLogmsgsStub);
                     sinon.assert.calledWith(ingestCLogmsgsStub, data);
@@ -582,7 +591,7 @@ describe('al_aws_collector tests', function() {
                     context, 'paws', AlAwsCollector.IngestTypes.LOGMSGS, '1.0.0', creds);
                 var data = 'some-data';
                 let spy = sinon.spy(collector, "updateEndpoints");
-                collector.send(data, false, function (error) {
+                collector.send(data, false,'',function (error) {
                     assert.ifError(error);
                     sinon.assert.calledOnce(ingestCLogmsgsStub);
                     sinon.assert.calledWith(ingestCLogmsgsStub, data);
@@ -603,12 +612,29 @@ describe('al_aws_collector tests', function() {
                 var collector = new AlAwsCollector(
                     context, 'cwe', AlAwsCollector.IngestTypes.VPCFLOW, '1.0.0', creds);
                 var data = 'some-data';
-                collector.send(data, true, function(error) {
+                collector.send(data, true,AlAwsCollector.IngestTypes.VPCFLOW,function(error) {
                     assert.ifError(error);
                     sinon.assert.calledOnce(ingestCVpcFlowStub);
                     zlib.deflate(data, function(compressionErr, compressed) {
                         assert.ifError(compressionErr);
                         sinon.assert.calledWith(ingestCVpcFlowStub, compressed);
+                        done();
+                    });
+                });
+            });
+        });
+
+        it('send lmcstats success', function (done) {
+            AlAwsCollector.load().then(function (creds) {
+                var collector = new AlAwsCollector(
+                    context, 'paws', AlAwsCollector.IngestTypes.LMCSTATS, '1.0.0', creds);
+                var data = 'some-data';
+                collector.send(data, true, AlAwsCollector.IngestTypes.LMCSTATS, function (error) {
+                    assert.ifError(error);
+                    sinon.assert.calledOnce(ingestCLmcStatsStub);
+                    zlib.deflate(data, function (compressionErr, compressed) {
+                        assert.ifError(compressionErr);
+                        sinon.assert.calledWith(ingestCLmcStatsStub, compressed);
                         done();
                     });
                 });
@@ -620,7 +646,7 @@ describe('al_aws_collector tests', function() {
         var sendStub;
         before(function() {
             sendStub = sinon.stub(AlAwsCollector.prototype, 'send').callsFake(
-                function fakeFn(data, compress, callback) {
+                function fakeFn(data, compress,ingestType,callback) {
                     return callback(null, null);
                 });
         });


### PR DESCRIPTION
### Problem Description
Collector not allow to send the multiple ingest type.

Ex. For Paws and S3 , we have to send logmsgs as well as lmcstats. For GD collector need to send secmsgs as well as logmsgs.

### Solution Description
Allow to accept ingest type if some one want to send ,otherwise it will set from collector. _ingestType . 

