### PR TITLE
ENG-26177: Added packageType in NOUPDATE_CONFIG_PARAMS as it breaking the selfupdate with latest aws-sdk version

### DIFF
--- a/al_aws_collector.js
+++ b/al_aws_collector.js
@@ -41,7 +41,8 @@ const NOUPDATE_CONFIG_PARAMS = [
     'StateReasonCode',
     'LastUpdateStatus',
     'LastUpdateStatusReason',
-    'LastUpdateStatusReasonCode'
+    'LastUpdateStatusReasonCode',
+    'PackageType'
 ];
 
 function getDecryptedCredentials(callback) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/al-aws-collector-js",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "license": "MIT",
   "description": "Alert Logic AWS Collector Common Library",
   "repository": {


### PR DESCRIPTION
### Problem Description
In CWE collector with aws-sdk latest version we start getting issue with PackageType while updating config with lambda [updateFunctionConfiguration](https://github.com/alertlogic/al-aws-collector-js/blob/master/al_aws.js#L70)

### Solution Description
 Added the `PackageType` in NOUPDATE_CONFIG_PARAMS so that it will delete this param before calling to lambda.UpdateFunctionConfiguration .

