### PR TITLE
Add an option to fail an invocation without status send to Ingest.

### DIFF
--- a/al_aws_collector.js
+++ b/al_aws_collector.js
@@ -170,7 +170,7 @@ class AlAwsCollector {
     }
 
 
-    done(error , streamType) {
+    done(error , streamType, sendStatus = true) {
         let context = this._invokeContext;
         if (error) {
             // The lambda context tries to stringify errors, 
@@ -188,9 +188,13 @@ class AlAwsCollector {
             }
             // post stream specific error
             const status = streamType ? this.prepareErrorStatus(errorString, 'none', streamType) : this.prepareErrorStatus(errorString);
-            this.sendStatus(status, () => {
+            if (sendStatus) {
+                this.sendStatus(status, () => {
+                    context.fail(errorString);
+                });
+            } else {
                 context.fail(errorString);
-            });
+            }
         } else {
             return context.succeed();
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/al-aws-collector-js",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "license": "MIT",
   "description": "Alert Logic AWS Collector Common Library",
   "repository": {

--- a/test/al_aws_collector_test.js
+++ b/test/al_aws_collector_test.js
@@ -668,6 +668,44 @@ describe('al_aws_collector tests', function() {
                 });
             });
         });
+        
+        it('send error status successfully', function (done) {
+            var mockCtx = {
+                    invokedFunctionArn: colMock.FUNCTION_ARN,
+                    functionName: colMock.FUNCTION_NAME,
+                    fail: function (error) {
+                        sinon.assert.calledOnce(ingestCAgentstatusStub);
+                        done();
+                    },
+                    succeed: function () {
+                        assert.fail();
+                    }
+                };
+            AlAwsCollector.load().then(function (creds) {
+                var collector = new AlAwsCollector(
+                        mockCtx, 'paws', AlAwsCollector.IngestTypes.LOGMSGS, '1.0.0', creds);
+                collector.done({message : 'some_error'}, null, true);
+            });
+        });
+        
+        it('fail invocation without status send', function (done) {
+            var mockCtx = {
+                    invokedFunctionArn: colMock.FUNCTION_ARN,
+                    functionName: colMock.FUNCTION_NAME,
+                    fail: function (error) {
+                        sinon.assert.notCalled(ingestCAgentstatusStub);
+                        done();
+                    },
+                    succeed: function () {
+                        assert.fail();
+                    }
+                };
+            AlAwsCollector.load().then(function (creds) {
+                var collector = new AlAwsCollector(
+                        mockCtx, 'paws', AlAwsCollector.IngestTypes.LOGMSGS, '1.0.0', creds);
+                collector.done({message : 'some_error'}, null, false);
+            });
+        });
     });
     
     describe('mocking send', function() {


### PR DESCRIPTION
### Problem Description
In some cases collector may want to fail without Ingest status update.

### Solution Description
And boolean option into `done()`.

