### PR TITLE
Check the custom error metrics data before sending status ok to assets

### DIFF
--- a/al_aws_collector.js
+++ b/al_aws_collector.js
@@ -417,19 +417,11 @@ class AlAwsCollector {
         function(err, checkinParts) {
 
             const invocationStatsDatapoints = checkinParts[1].statistics[0].Datapoints ? checkinParts[1].statistics[0].Datapoints : checkinParts[1].statistics;
-            const lambdaErrorStatsDatapoints = checkinParts[1].statistics[1].Datapoints ? checkinParts[1].statistics[1].Datapoints : checkinParts[1].statistics;
-            // If no custom metrics send or if no error happened then custom metrics will return empty [], so add sum:0 to not break the condition check.
-            const customErrorStats = checkinParts[1].statistics[2];
-            const customErrorStatsDatapoints = customErrorStats && customErrorStats.Datapoints && customErrorStats.Datapoints.length > 0 ? customErrorStats.Datapoints : [{ Sum: 0 }];
+            const errorStatsDatapoints = checkinParts[1].statistics[1].Datapoints ? checkinParts[1].statistics[1].Datapoints : checkinParts[1].statistics;
             const collectorStreams = collector._streams;
-            /**
-             * If any collector pass the custom error metrics;
-             * It should check Lambda Error metrics and Custom error metrics both and send the status 'ok' to assets if there is no error(i.e. Sum:0).
-             * else it will only check Lambda Error metrics before sending the status 'ok' to assets.
-             */
 
             if (checkinParts[0].status === 'ok' && invocationStatsDatapoints.length > 0 && invocationStatsDatapoints[0].Sum > 0
-                && (lambdaErrorStatsDatapoints.length > 0 && lambdaErrorStatsDatapoints[0].Sum === 0 && customErrorStatsDatapoints[0].Sum === 0)) {
+                && errorStatsDatapoints.length > 0 && errorStatsDatapoints[0].Sum === 0) {
 
                 let streamSpecificStatus = [];
                 if (Array.isArray(collectorStreams) && collectorStreams.length > 0) {

--- a/al_aws_collector.js
+++ b/al_aws_collector.js
@@ -417,11 +417,19 @@ class AlAwsCollector {
         function(err, checkinParts) {
 
             const invocationStatsDatapoints = checkinParts[1].statistics[0].Datapoints ? checkinParts[1].statistics[0].Datapoints : checkinParts[1].statistics;
-            const errorStatsDatapoints = checkinParts[1].statistics[1].Datapoints ? checkinParts[1].statistics[1].Datapoints : checkinParts[1].statistics ;
+            const lambdaErrorStatsDatapoints = checkinParts[1].statistics[1].Datapoints ? checkinParts[1].statistics[1].Datapoints : checkinParts[1].statistics;
+            // If no custom metrics send or if no error happened then custom metrics will return empty [], so add sum:0 to not break the condition check.
+            const customErrorStats = checkinParts[1].statistics[2];
+            const customErrorStatsDatapoints = customErrorStats && customErrorStats.Datapoints && customErrorStats.Datapoints.length > 0 ? customErrorStats.Datapoints : [{ Sum: 0 }];
             const collectorStreams = collector._streams;
+            /**
+             * If any collector pass the custom error metrics;
+             * It should check Lambda Error metrics and Custom error metrics both and send the status 'ok' to assets if there is no error(i.e. Sum:0).
+             * else it will only check Lambda Error metrics before sending the status 'ok' to assets.
+             */
 
             if (checkinParts[0].status === 'ok' && invocationStatsDatapoints.length > 0 && invocationStatsDatapoints[0].Sum > 0
-                && errorStatsDatapoints.length > 0 && errorStatsDatapoints[0].Sum === 0) {
+                && (lambdaErrorStatsDatapoints.length > 0 && lambdaErrorStatsDatapoints[0].Sum === 0 && customErrorStatsDatapoints[0].Sum === 0)) {
 
                 let streamSpecificStatus = [];
                 if (Array.isArray(collectorStreams) && collectorStreams.length > 0) {

--- a/al_aws_collector.js
+++ b/al_aws_collector.js
@@ -414,46 +414,52 @@ class AlAwsCollector {
                 });
             }
         ],
-        function(err, checkinParts) {
-
+        function (err, checkinParts) {
             const invocationStatsDatapoints = checkinParts[1].statistics[0].Datapoints ? checkinParts[1].statistics[0].Datapoints : checkinParts[1].statistics;
             const errorStatsDatapoints = checkinParts[1].statistics[1].Datapoints ? checkinParts[1].statistics[1].Datapoints : checkinParts[1].statistics;
             const collectorStreams = collector._streams;
-
-            if (checkinParts[0].status === 'ok' && invocationStatsDatapoints.length > 0 && invocationStatsDatapoints[0].Sum > 0
-                && errorStatsDatapoints.length > 0 && errorStatsDatapoints[0].Sum === 0) {
-
-                let streamSpecificStatus = [];
-                if (Array.isArray(collectorStreams) && collectorStreams.length > 0) {
-                    collectorStreams.map(streamType => {
-                        let okStatus = collector.prepareHealthyStatus('none', `${collector._applicationId}_${streamType}`);
-                        streamSpecificStatus.push(okStatus);
-                    });
-                } else {
-                    let okStatus = collector.prepareHealthyStatus();
-                    streamSpecificStatus.push(okStatus);
+            async.parallel([
+                function (asyncCallback) {
+                    if (checkinParts[0].status === 'ok' && invocationStatsDatapoints.length > 0 && invocationStatsDatapoints[0].Sum > 0
+                        && errorStatsDatapoints.length > 0 && errorStatsDatapoints[0].Sum === 0) {
+                        let streamSpecificStatus = [];
+                        if (Array.isArray(collectorStreams) && collectorStreams.length > 0) {
+                            collectorStreams.map(streamType => {
+                                let okStatus = collector.prepareHealthyStatus('none', `${collector._applicationId}_${streamType}`);
+                                streamSpecificStatus.push(okStatus);
+                            });
+                        } else {
+                            let okStatus = collector.prepareHealthyStatus();
+                            streamSpecificStatus.push(okStatus);
+                        }
+                        // make api call to send status ok
+                        collector.sendStatus(streamSpecificStatus, () => {
+                            return asyncCallback(null);
+                        });
+                    }
+                    else {
+                        return asyncCallback(null);
+                    }
+                },
+                function (asyncCallback) {
+                    const checkin = Object.assign(
+                        collector.getProperties(), checkinParts[0], checkinParts[1]
+                    );
+                    collector._azcollectc.checkin(checkin)
+                        .then(resp => {
+                            if (resp && resp.force_update === true) {
+                                console.info('AWSC0004 Force update');
+                                collector.update(asyncCallback);
+                            }
+                            else {
+                                return asyncCallback(null);
+                            }
+                        })
+                        .catch(exception => {
+                            return asyncCallback(exception);
+                        });
                 }
-                // make api call to send status ok
-                collector.sendStatus(streamSpecificStatus, () => {
-                    return context.succeed();
-                });
-            }
-            const checkin = Object.assign(
-                collector.getProperties(), checkinParts[0], checkinParts[1]
-            );
-            collector._azcollectc.checkin(checkin)
-            .then(resp => {
-                if(resp && resp.force_update === true){
-                    console.info('AWSC0004 Force update');
-                    return collector.update(callback);
-                }
-                else{
-                    return callback(null);
-                }
-            })
-            .catch(exception => {
-                return callback(exception);
-            });
+            ], callback);
         });
     }
     

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/al-aws-collector-js",
-  "version": "4.0.5",
+  "version": "4.0.6",
   "license": "MIT",
   "description": "Alert Logic AWS Collector Common Library",
   "repository": {

--- a/statistics_templates.js
+++ b/statistics_templates.js
@@ -90,6 +90,37 @@ var getLambdaMetrics = function (functionName, metricName, callback) {
     };
     return getMetricStatistics(params, callback);
 };
+/**
+ * 
+ * @param {*} functionName - Lambda function name
+ * @param {*} metricName -Custom metrics name
+ * @param {*} namespace - Custom namespace 
+ * @param {*} customDimesions - Extra dimentions object other than function name if you added while creating the custom metrics
+ * @param {*} callback 
+ * @returns 
+ */
+var getCustomMetrics = function (functionName, metricName, namespace, customDimesions, callback) {
+    let dimensions =
+        [
+            {
+                Name: 'FunctionName',
+                Value: functionName
+            }
+        ]
+    if (customDimesions) {
+        dimensions.push(customDimesions);
+    }
+    var params = {
+        Dimensions: dimensions,
+        MetricName: metricName,
+        Namespace: namespace,
+        Statistics: ['Sum'],
+        StartTime: moment().subtract(AWS_STATISTICS_PERIOD_MINUTES, 'minutes').toISOString(),
+        EndTime: new Date(),
+        Period: 60 * AWS_STATISTICS_PERIOD_MINUTES   /* 15 mins as seconds */
+    };
+    return getMetricStatistics(params, callback);
+};
 
 var getKinesisMetrics = function (streamName, metricName, callback) {
     var params = {
@@ -132,5 +163,6 @@ module.exports = {
     getKinesisMetrics : getKinesisMetrics,
 
     // functions which return funs:
-    getAllKinesisMetricsFuns : getAllKinesisMetricsFuns
+    getAllKinesisMetricsFuns : getAllKinesisMetricsFuns,
+    getCustomMetrics: getCustomMetrics,
 };

--- a/test/al_aws_collector_test.js
+++ b/test/al_aws_collector_test.js
@@ -438,12 +438,6 @@ describe('al_aws_collector tests', function() {
                     return resolve(collector.handleEvent(testEvent));
                 });
                 promise.then((result) => {
-                    sinon.assert.calledOnce(customErrorHealthCheck);
-                    sinon.assert.calledWith(
-                        alserviceStub.post,
-                        colMock.CHECKIN_URL,
-                        colMock.CHECKIN_AZCOLLECT_QUERY_CUSTOM_HEALTHCHECK_ERROR
-                    );
                     sinon.assert.notCalled(prepareHealthyStatusSpy);
                     sinon.assert.notCalled(sendStatusSpy);
                 });

--- a/test/collector_mock.js
+++ b/test/collector_mock.js
@@ -135,26 +135,6 @@ const CHECKIN_AZCOLLECT_QUERY = {
     }
 };
 
-const CHECKIN_AZCOLLECT_QUERY_WITH_CUSTOM_STATS = {
-    body: {
-        awsAccountId: '123456789012',
-        collectorId: 'collector-id',
-        applicationId: 'app-id',
-        dataType: 'secmsgs',
-        details: [],
-        functionName: 'test-VpcFlowCollectLambdaFunction',
-        region: 'us-east-1',
-        stackName: 'test-stack-01',
-        version: '1.0.0',
-        status: 'ok',
-        statistics:[
-            {'Label':'Invocations','Datapoints':[{'Timestamp':'2017-11-21T16:40:00Z','Sum':1,'Unit':'Count'}]},
-            {'Label':'Errors','Datapoints':[{'Timestamp':'2017-11-21T16:40:00Z','Sum':1,'Unit':'Count'}]},
-            {'Label':'PawsClientError','Datapoints':[{'Timestamp':'2017-11-21T16:40:00Z','Sum':1,'Unit':'Count'}]}
-        ]
-    }
-};
-
 const CHECKIN_AZCOLLECT_QUERY_CUSTOM_HEALTHCHECK_ERROR = {
     body: {
         awsAccountId: '123456789012',
@@ -405,7 +385,6 @@ module.exports = {
 
     CHECKIN_URL : CHECKIN_URL,
     CHECKIN_AZCOLLECT_QUERY : CHECKIN_AZCOLLECT_QUERY,
-    CHECKIN_AZCOLLECT_QUERY_WITH_CUSTOM_STATS_ERROR :CHECKIN_AZCOLLECT_QUERY_WITH_CUSTOM_STATS,
     CHECKIN_AZCOLLECT_QUERY_CUSTOM_HEALTHCHECK_ERROR : CHECKIN_AZCOLLECT_QUERY_CUSTOM_HEALTHCHECK_ERROR,
     CF_DESCRIBE_STACKS_RESPONSE : CF_DESCRIBE_STACKS_RESPONSE,
     CHECKIN_ERROR_AZCOLLECT_QUERY : CHECKIN_ERROR_AZCOLLECT_QUERY,

--- a/test/collector_mock.js
+++ b/test/collector_mock.js
@@ -135,6 +135,26 @@ const CHECKIN_AZCOLLECT_QUERY = {
     }
 };
 
+const CHECKIN_AZCOLLECT_QUERY_WITH_CUSTOM_STATS = {
+    body: {
+        awsAccountId: '123456789012',
+        collectorId: 'collector-id',
+        applicationId: 'app-id',
+        dataType: 'secmsgs',
+        details: [],
+        functionName: 'test-VpcFlowCollectLambdaFunction',
+        region: 'us-east-1',
+        stackName: 'test-stack-01',
+        version: '1.0.0',
+        status: 'ok',
+        statistics:[
+            {'Label':'Invocations','Datapoints':[{'Timestamp':'2017-11-21T16:40:00Z','Sum':1,'Unit':'Count'}]},
+            {'Label':'Errors','Datapoints':[{'Timestamp':'2017-11-21T16:40:00Z','Sum':1,'Unit':'Count'}]},
+            {'Label':'PawsClientError','Datapoints':[{'Timestamp':'2017-11-21T16:40:00Z','Sum':1,'Unit':'Count'}]}
+        ]
+    }
+};
+
 const CHECKIN_AZCOLLECT_QUERY_CUSTOM_HEALTHCHECK_ERROR = {
     body: {
         awsAccountId: '123456789012',
@@ -385,6 +405,7 @@ module.exports = {
 
     CHECKIN_URL : CHECKIN_URL,
     CHECKIN_AZCOLLECT_QUERY : CHECKIN_AZCOLLECT_QUERY,
+    CHECKIN_AZCOLLECT_QUERY_WITH_CUSTOM_STATS_ERROR :CHECKIN_AZCOLLECT_QUERY_WITH_CUSTOM_STATS,
     CHECKIN_AZCOLLECT_QUERY_CUSTOM_HEALTHCHECK_ERROR : CHECKIN_AZCOLLECT_QUERY_CUSTOM_HEALTHCHECK_ERROR,
     CF_DESCRIBE_STACKS_RESPONSE : CF_DESCRIBE_STACKS_RESPONSE,
     CHECKIN_ERROR_AZCOLLECT_QUERY : CHECKIN_ERROR_AZCOLLECT_QUERY,


### PR DESCRIPTION
### Problem Description

Checkin function update the status to `ok` if there is no error on Lambda Error metrics. 

But Paws collector not sending error to Lambda error metrics in few scenario but sending error to custom metrics (like pawsClientError/pawsIngestError).

### Solution Description
If any collector send the custom error metrics then check the datapoints of custom error metric and Lambda error metrics both. If there is no error on both metrics then only we will send the status 'ok' to assets.

