### PR TITLE
Handle the exception and improve the logger

### DIFF
--- a/al_aws.js
+++ b/al_aws.js
@@ -35,10 +35,10 @@ var selfUpdate = function (callback) {
       S3Key: process.env.aws_lambda_zipfile_name
     };
     var lambda = new AWS.Lambda(LAMBDA_CONFIG);
-    logger.info('AWSC0100 Performing lambda self-update with params: ', JSON.stringify(params));
+    logger.info(`AWSC0100 Performing lambda self-update with params: ${JSON.stringify(params)}`);
     lambda.updateFunctionCode(params, function(err, data) {
         if (err) {
-            logger.info('AWSC0101 Lambda self-update error: ', err);
+            logger.info(`AWSC0101 Lambda self-update error: ${JSON.stringify(err)}`);
         } else {
             logger.info('AWSC0102 Lambda self-update successful.  Data: ' + JSON.stringify(data));
         }

--- a/al_aws_collector.js
+++ b/al_aws_collector.js
@@ -312,7 +312,7 @@ class AlAwsCollector {
                     // the collector should register even if there is an error in getting the endpoints.
                     this.updateEndpoints((err, newConfig) => {
                         if(err){
-                            logger.warn('AWSC0002 Error updating endpoints', err);
+                            logger.warn(`AWSC0002 Error updating endpoints ${err}`);
                         } else {
                             // reassign env vars because the config change occurs in the same run in registration.
                             const {
@@ -360,7 +360,7 @@ class AlAwsCollector {
                     // the collector should handle check in even if there is an error in getting the endpoints.
                     collector.updateEndpoints((err, newConfig) => {
                         if (err) {
-                            logger.warn('AWSC0014 Error updating endpoints', err);
+                            logger.warn(`AWSC0014 Error updating endpoints ${err}`);
                         } else {
                             // reassign env vars because the config change occurs in the same run in handle check in.
                             const {
@@ -535,7 +535,7 @@ class AlAwsCollector {
                 return callback(null, resp);
             })
             .catch(exception => {
-                logger.warn('AWSC0011 Collector deregistration failed. ', exception);
+                logger.warn(`AWSC0011 Collector deregistration failed. ${exception}`);
                 return callback(exception);
             });
     }
@@ -554,7 +554,7 @@ class AlAwsCollector {
                     // the collector should send status even if there is an error in getting the endpoints.
                     collector.updateEndpoints((err, newConfig) => {
                         if (err) {
-                            logger.warn('AWSC0016 Error updating endpoints', err);
+                            logger.warn(`AWSC0016 Error updating endpoints ${err}`);
                         } else {
                             // reassign env vars because the config change occurs in the same run in sending status.
                             const {
@@ -586,8 +586,9 @@ class AlAwsCollector {
                                     return asyncCallback(null, resp);
                                 })
                                 .catch(exception => {
-                                    logger.warn('AWSC0013 Collector status send failed: ', exception);
-                                    return asyncCallback(exception);
+                                    logger.warn(`AWSC0013 Collector status send failed: ${exception.message}`);
+                                    logger.debug(exception);
+                                    return asyncCallback(exception.message);
                                 });
                         }
                     });
@@ -610,7 +611,7 @@ class AlAwsCollector {
                     // the collector should send data even if there is an error in getting the endpoints.
                     collector.updateEndpoints((err, newConfig) => {
                         if (err) {
-                            logger.warn('AWSC0015 Error updating endpoints', err);
+                            logger.warn(`AWSC0015 Error updating endpoints ${err}`);
                         } else {
                             // reassign env vars because the config change occurs in the same run in sending data.
                             const {
@@ -676,7 +677,8 @@ class AlAwsCollector {
                     return callback(null, resp);
                 })
                 .catch(exception => {
-                    return callback(exception);
+                    logger.debug(exception);
+                    return callback(`AWSC0018 failed to send the logmsgs : ${exception.message}`);
                 });
                 break;
             case AlAwsCollector.IngestTypes.LMCSTATS:
@@ -685,7 +687,8 @@ class AlAwsCollector {
                     return callback(null, resp);
                 })
                 .catch(exception => {
-                    return callback(exception);
+                    logger.debug(exception);
+                    return callback(`AWSC0019 failed to send the lmcstats : ${exception.message}`);
                 });
                 break;
             default:
@@ -813,7 +816,7 @@ class AlAwsCollector {
         ],
         function(err, config) {
             if (err) {
-                logger.info('AWSC0006 Lambda self-update config error: ', err);
+                logger.info(`AWSC0006 Lambda self-update config error: ${err}`);
             } else {
                 if (config !== undefined) {
                     logger.info('AWSC0007 Lambda self-update config successful.');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/al-aws-collector-js",
-  "version": "4.0.9",
+  "version": "4.0.10",
   "license": "MIT",
   "description": "Alert Logic AWS Collector Common Library",
   "repository": {

--- a/test/al_aws_collector_test.js
+++ b/test/al_aws_collector_test.js
@@ -655,7 +655,7 @@ describe('al_aws_collector tests', function() {
                 collector.send(data, false, '', function(error) {
                     sinon.assert.calledOnce(ingestCLogmsgsStub);
                     sinon.assert.calledWith(ingestCLogmsgsStub, data);
-                    assert.equal(error, `AWSC0005 failed to send the logmsgs : ${logmsgErr.message}`);
+                    assert.equal(error, `AWSC0018 failed to send the logmsgs : ${logmsgErr.message}`);
                     done();   
                 });
             });

--- a/test/al_aws_collector_test.js
+++ b/test/al_aws_collector_test.js
@@ -638,6 +638,28 @@ describe('al_aws_collector tests', function() {
                 });
             });
         });
+
+        it('send logmsgs got failed', function(done) {
+                ingestCLogmsgsStub.restore();
+                let logmsgErr = {"errorType":"StatusCodeError","errorMessage":"400 - \"{\\\"error\\\":\\\"body encoding invalid\\\"}\"","name":"StatusCodeError","statusCode":400,"message":"400 - \"{\\\"error\\\":\\\"body encoding invalid\\\"}\"","error":"{\"error\":\"body encoding invalid\"}","options":{"method":"POST","url":"https://api.global-services.us-west-2.global.alertlogic.com/ingest/v1/48649/data/logmsgs"}};
+                ingestCLogmsgsStub = sinon.stub(m_alCollector.IngestC.prototype, 'sendLogmsgs').callsFake(
+                function fakeFn(data, callback) {
+                    return new Promise (function(resolve, reject) {
+                        reject(logmsgErr);
+                    });
+                });
+            AlAwsCollector.load().then(function(creds) {
+                var collector = new AlAwsCollector(
+                    context, 'paws', AlAwsCollector.IngestTypes.LOGMSGS, '1.0.0', creds);
+                var data = 'some-data';
+                collector.send(data, false, '', function(error) {
+                    sinon.assert.calledOnce(ingestCLogmsgsStub);
+                    sinon.assert.calledWith(ingestCLogmsgsStub, data);
+                    assert.equal(error, `AWSC0005 failed to send the logmsgs : ${logmsgErr.message}`);
+                    done();   
+                });
+            });
+        });
         
         it('send log success with env vars not set', function (done) {
             const envIngestApi = process.env.ingest_api;


### PR DESCRIPTION
### Problem Description
1. Ingest service returning buffer data in error(mostly see for logmsgs) and which is huge in size sending to cloud watch.
2. Logger methods(info, warn, error): 2nd parameters is metadata and it should be in object/list but if send the string it will not get combine in message ,

### Solution Description
1.Returning error.message string instead  of whole error object. Added debug incase if you need to check compete error stack.
2.If error is string combine with static message and if its object then pass it as 2nd parameters which will be  get added as metadata.
