### PR TITLE
Exclude Architectures from updates. Bump number of retries.

### DIFF
--- a/al_aws.js
+++ b/al_aws.js
@@ -21,7 +21,7 @@ const LAMBDA_CONFIG = {
         maxRetries: 10
 };
 const LAMBDA_UPDATE_RETRY = {
-        times: 10,
+        times: 20,
         // intervals of 200, 400, 800, 1600, 3200, ... ms)
         interval: function(retryCount) {
             return Math.min(100 * Math.pow(2, retryCount), 5000);

--- a/al_aws_collector.js
+++ b/al_aws_collector.js
@@ -29,22 +29,24 @@ var AIMS_DECRYPTED_CREDS = null;
 const AL_SERVICES = ['ingest', 'azcollect'];
 
 const NOUPDATE_CONFIG_PARAMS = [
-    'FunctionArn',
-    'Role',
-    'CodeSize',
-    'LastModified',
+    'Architectures',
     'CodeSha256',
-    'Version',
-    'MasterArn',
-    'RevisionId',
-    'State',
-    'StateReason',
-    'StateReasonCode',
+    'CodeSize',
+    'FunctionArn',
+    'LastModified',
     'LastUpdateStatus',
     'LastUpdateStatusReason',
     'LastUpdateStatusReasonCode',
-    'PackageType'
+    'MasterArn',
+    'PackageType',
+    'RevisionId',
+    'Role',
+    'State',
+    'StateReason',
+    'StateReasonCode',
+    'Version'
 ];
+
 
 function getDecryptedCredentials(callback) {
     if (AIMS_DECRYPTED_CREDS) {
@@ -897,8 +899,7 @@ class AlAwsCollector {
     _applyConfigChanges(newValues, config, callback) {
         var newConfig = {};
         Object.assign(newConfig, config);
-        
-        
+
         try {
             Object.keys(newValues).forEach(
                 function(item) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/al-aws-collector-js",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "license": "MIT",
   "description": "Alert Logic AWS Collector Common Library",
   "repository": {

--- a/ps_spec.yml
+++ b/ps_spec.yml
@@ -8,7 +8,7 @@ stages:
             - pull_request
             - pull_request:
                 trigger_phrase: test it
-        image: node:12
+        image: node:14
         compute_size: small
         commands:
             - make test
@@ -17,7 +17,7 @@ stages:
         name: Master Push - Publish
         when:
             - push: ['master']
-        image: node:12
+        image: node:14
         compute_size: small
         commands:
             - |

--- a/test/al_aws_test.js
+++ b/test/al_aws_test.js
@@ -213,7 +213,7 @@ describe('al_aws Tests', function() {
                 assert.equal('Function update is in progress', err.message);
                 done();
             });
-        }).timeout(30000);
+        }).timeout(120000);
     });
 });
 


### PR DESCRIPTION
### Problem Description
Some updates fail due to timeouts and `Architectures` being present in function config

### Solution Description
Exclude `Architectures` from function config and bump the number of retries to 20.