### PR TITLE
Handle the S3TestEvent

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/al-aws-collector-js",
-  "version": "4.1.9",
+  "version": "4.1.10",
   "license": "MIT",
   "description": "Alert Logic AWS Collector Common Library",
   "repository": {

--- a/test/al_aws_collector_test.js
+++ b/test/al_aws_collector_test.js
@@ -250,6 +250,25 @@ describe('al_aws_collector tests', function() {
         });
     });
 
+    it('Check TestEvent succeed without any error', function(done) {
+        var mockCtx = {
+            invokedFunctionArn : colMock.FUNCTION_ARN,
+            functionName : colMock.FUNCTION_NAME,
+            fail : function(error) {
+                assert.fail(error);
+            },
+            succeed : function() {
+                done();
+            }
+        };
+
+        AlAwsCollector.load().then(function(creds) {
+            let collector = new AlAwsCollector(
+                    mockCtx, 's3', AlAwsCollector.IngestTypes.LOGMSGS,'1.0.0', creds, undefined, [], []);
+            const testEvent = colMock.S3_TEST_EVENT;
+            collector.handleEvent(testEvent);
+        });
+    });
     describe('checkin success', function() {
 
         var mockContext = {

--- a/test/collector_mock.js
+++ b/test/collector_mock.js
@@ -416,6 +416,16 @@ const CHECKIN_SNS_TRIGGER = {
     ]
 };
 
+const S3_TEST_EVENT = {
+    Records: [
+        {
+            messageId: "6a562eba-42f3-448e-a0d7-77962c0e9510",
+            body: "{\"Type\":\"Notification\",\"MessageId\":\"4189c853-f31a-5aae-bd1c-93802b\",\"TopicArn\":\"arn:aws:sns:us-east-1:352283894008:test-AlertLogicS3SNSTopic\",\"Subject\":\"Amazon S3 Notification\",\"Message\":{\"Service\":\"Amazon S3\",\"Event\":\"s3:TestEvent\",\"Time\":\"2022-10-30T12:33:44.334Z\",\"Bucket\":\"tests3-bucket\",\"RequestId\":\"NPB3KH7AWA1TJ02\",\"HostId\":\"3aaDM8JRvILD6SslQgA=\"},\"Timestamp\":\"2022-10-30T12:33:44.385Z\",\"SignatureVersion\":\"1\",\"Signature\":\"4jz2NpwkVDCX4Q==\",\"SigningCertURL\":\"https://sns.us-east-1.amazonaws.com/SimpleNotificationService-56e67fcb4.pem\",\"UnsubscribeURL\":\"https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-1:352283894008:test-AlertLogicS3SNSTopic:35f45ee3-20fb-42cbf\"}",
+            awsRegion: "us-east-1"
+        }
+    ]
+};
+
 module.exports = {
     initProcessEnv : initProcessEnv,
     FUNCTION_ARN : FUNCTION_ARN,
@@ -449,5 +459,6 @@ module.exports = {
     S3_CONFIGURATION_FILE_CHANGE : S3_CONFIGURATION_FILE_CHANGE,
     LAMBDA_FUNCTION_CONFIGURATION : LAMBDA_FUNCTION_CONFIGURATION,
     LAMBDA_FUNCTION_CONFIGURATION_CHANGED : LAMBDA_FUNCTION_CONFIGURATION_CHANGED,
-    LAMBDA_FUNCTION_CONFIGURATION_WITH_STATE : LAMBDA_FUNCTION_CONFIGURATION_WITH_STATE
+    LAMBDA_FUNCTION_CONFIGURATION_WITH_STATE : LAMBDA_FUNCTION_CONFIGURATION_WITH_STATE,
+    S3_TEST_EVENT : S3_TEST_EVENT
 };


### PR DESCRIPTION
### Problem Description
When we setup SQS notifications in an S3 bucket first time, for example, when you want to get a message when a new file is uploaded into the bucket, the first thing you get is an s3:TestEvent. This is only trigger once.

Currently we are throwing the error AWSC0012 Unknown event:" {\"Records\":[{\"messageId\":\"6a562eba-42f3-448e-a0d7-77962c0e9510\",\"body\":\"{\\\"Type\\\":\\\"Notification\\\",\\\"MessageId\\\":\\\"4189c853-1c-9380d872722b\\\",\\\"TopicArn\\\":\\\"arn:aws:sns:us-east-1:3323:test-AlertLogicS3SNSTopic\\\",\\\"Subject\\\":\\\"Amazon S3 Notification\\\",\\\"Message\\\":{\\\"Service\\\":\\\"Amazon S3\\\",\\\**"Event\\\":\\\"s3:TestEvent**\\\",\\\"Time\\\":\\\"2022-10-26T12:33:44.334Z\\\",\\\"Bucket\\\":\\\"tests3-bucket\\\",\\\"RequestId\\\":\\\"NP3TJ02\\\",\\\"HostId\\\":\\\"3aata8=\\\"},\\\"Timestamp\\\":\\\"2022-10-26T12:33:44.385Z\\\",\\\"SignatureVersion\\\":\\\"1\\\"}"
### Solution Description
How it was fixed? - implementation details
Skip the S3:testEvent and don’t thrown any error.