### PR TITLE
Handle the error if it failed to upload object in s3 bucket

### DIFF
--- a/health_checks.js
+++ b/health_checks.js
@@ -137,7 +137,7 @@ function handleIngestEncodingInvalidError(err, { data, key, bucketName }, callba
         if (bucket) {
             m_alAws.uploadS3Object({ data, key, bucket }, (err) => {
                 if (err) {
-                    logger.warn(`ALAWS00003 error while uploading the object ${JSON.stringify(err)}`);
+                    logger.warn(`ALAWS00003 error while uploading the ${key} object in ${bucket} bucket : ${JSON.stringify(err)}`);
                 }
                 return callback(null);
             });

--- a/health_checks.js
+++ b/health_checks.js
@@ -11,6 +11,7 @@
 const AWS = require('aws-sdk');
 
 const m_alAws = require('./al_aws');
+const logger = require('./logger');
 const INGEST_INVALID_ENCODING = {
     code: 400
 }
@@ -134,7 +135,12 @@ function handleIngestEncodingInvalidError(err, { data, key, bucketName }, callba
     if (err.httpErrorCode === INGEST_INVALID_ENCODING.code) {
         let bucket = bucketName ? bucketName : process.env.dl_s3_bucket_name;
         if (bucket) {
-            return m_alAws.uploadS3Object({ data, key, bucket }, callback);
+            m_alAws.uploadS3Object({ data, key, bucket }, (err) => {
+                if (err) {
+                    logger.warn(`ALAWS00003 error while uploading the object ${JSON.stringify(err)}`);
+                }
+                return callback(null);
+            });
         }
         else return callback(null);
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/al-aws-collector-js",
-  "version": "4.1.13",
+  "version": "4.1.14",
   "license": "MIT",
   "description": "Alert Logic AWS Collector Common Library",
   "repository": {


### PR DESCRIPTION
Added the error as warning and  just skip any error return while uploading the object.As we don’t want this error show as remediation to customer and move with new state to avoid collection delay.

