### PR TITLE
Consume the collector_status service to send the statuses for all PAWS and S3 collectors

### DIFF
--- a/al_aws_collector.js
+++ b/al_aws_collector.js
@@ -381,8 +381,7 @@ class AlAwsCollector {
                                 },
                                 function (mapErr, mapResult) {
                                     if (mapErr) {
-                                        logger.warn(`AWSC00021 Collector failed to update the status ${mapErr}`)
-                                     
+                                        logger.warn(`AWSC00021 Collector failed to update the status ${mapErr}`);
                                     } 
                                     return asyncCallback(null);
                                 }

--- a/al_aws_collector.js
+++ b/al_aws_collector.js
@@ -553,6 +553,11 @@ class AlAwsCollector {
             callback);
     }
 
+    /**
+     * Function update endpoint api for different AL service if it is not available in env variable.
+     * @param {*} asyncCallback 
+     * @returns 
+     */
     updateApiEndpoint(asyncCallback) {
         const collector = this;
         const {
@@ -584,6 +589,13 @@ class AlAwsCollector {
             return asyncCallback(null);
         }
     }
+
+    /**
+     * Send the status to collector_status service
+     * @param {*} collectorStatusStream - Collector those having streams use that else stream will be application_id
+     * @param {*} status -It's a json object form using setCollectorStatus function
+     * @param {*} callback 
+     */
     sendCollectorStatus(collectorStatusStream, status, callback) {
         let collector = this;
         async.waterfall([
@@ -615,6 +627,7 @@ class AlAwsCollector {
         ],
             callback);
     }
+
     send(data, compress = true, ingestType, callback) {
         var collector = this;
         async.waterfall([

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/al-aws-collector-js",
-  "version": "4.1.15",
+  "version": "4.1.16",
   "license": "MIT",
   "description": "Alert Logic AWS Collector Common Library",
   "repository": {
@@ -32,7 +32,7 @@
     "sinon": "^15.0.1"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "3.0.5",
+    "@alertlogic/al-collector-js": "3.0.6",
     "async": "^3.2.4",
     "cfn-response": "1.0.1",
     "deep-equal": "^2.2.0",

--- a/test/collector_mock.js
+++ b/test/collector_mock.js
@@ -7,6 +7,7 @@ const STACK_NAME = 'test-stack-01';
 const AL_API = 'api.global-services.global.alertlogic.com';
 const INGEST_API = 'ingest.global-services.global.alertlogic.com';
 const AZCOLLECT_API = 'azcollect.global-services.global.alertlogic.com';
+const COLLECTOR_STATUS_API = 'collector-status-api.global.alertlogic.com';
 const CTRL_SNS_ARN = 'arn:aws:sns:us-east-1:123456789012:AlCollectorControlSNS';
 
 var initProcessEnv = function() {
@@ -24,6 +25,7 @@ var initProcessEnv = function() {
     process.env.collector_id = 'collector-id';
     process.env.al_application_id = 'app-id';
     process.env.al_control_sns_arn = CTRL_SNS_ARN;
+    process.env.collector_status_api = COLLECTOR_STATUS_API;
 };
 
 


### PR DESCRIPTION
### Problem Description
[ENG-43646](https://alertlogic.atlassian.net/jira/software/c/projects/ENG/boards/269?modal=detail&selectedIssue=ENG-43646) : [al-aws-collector-js] Send status updates to CollectorStatus service.
### Solution Description
Sending the collector status to collector status service after each lambda function execution and during checkin ..etc.

- Added the `setCollectorStatus` function to form the excepted  healthy and error status format to send collector service.
- Added the collector_status in AL_SERVICES list to fetch the endpoint for collector status service and update in environment variable if collector_status_api is undefined or not there .
- Added the `sendCollectorStatus` function which consume the collecctor_status put method to send the status to collector status service. Refer al-collector.js [collector_statusc.js pr](https://github.com/alertlogic/al-collector-js/pull/54)
- Handle the callback already called error by using async.each instead of map during checkin event.
- Handle the 304(Not Modified) error return from collector status service if there is no change in status.
- Remove the redundant code by moving in new  `updateApiEndpoint` function and call where ever required.
