### PR TITLE
Set the time stamp in milliseconds to avoid 409(time conflict) error from collector_status service

### DIFF
--- a/al_aws_collector.js
+++ b/al_aws_collector.js
@@ -203,7 +203,7 @@ class AlAwsCollector {
             inst_type: 'collector',
             stream: stream,
             status_id: this._collectorId,
-            timestamp: moment().unix(),
+            timestamp: moment().valueOf(),
             reported_by: this._collectorType,
             collection_type: this._applicationId
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/al-aws-collector-js",
-  "version": "4.1.16",
+  "version": "4.1.17",
   "license": "MIT",
   "description": "Alert Logic AWS Collector Common Library",
   "repository": {


### PR DESCRIPTION

### Problem Description
Collector status return 409 if time stamp conflict.
### Solution Description
To avoid that sending time stamp in milliseconds. 

