### PR TITLE
Bump the package to encode the stream and handle lambda timeout issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/al-aws-collector-js",
-  "version": "4.1.17",
+  "version": "4.1.18",
   "license": "MIT",
   "description": "Alert Logic AWS Collector Common Library",
   "repository": {
@@ -32,7 +32,7 @@
     "sinon": "^15.0.1"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "3.0.6",
+    "@alertlogic/al-collector-js": "3.0.7",
     "async": "^3.2.4",
     "cfn-response": "1.0.1",
     "deep-equal": "^2.2.0",


### PR DESCRIPTION
### Problem Description

- Collector service return 501 error while validating url because stream contain / which is not excepted
- Duplication of SQS message happened because of lambda timeout issue.

### Solution Description
1.Encode the stream value while making the api call.
2. By default value of maxRetryTime is forever , so updating it to 3min
Refere al-aws-collector.js [pr](https://github.com/alertlogic/al-collector-js/pull/56)

