### PR TITLE
Removed agentStatus method and added validation for collectors_status service call

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/al-aws-collector-js",
-  "version": "4.1.19",
+  "version": "4.1.20",
   "license": "MIT",
   "description": "Alert Logic AWS Collector Common Library",
   "repository": {
@@ -32,7 +32,7 @@
     "sinon": "^15.2.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "3.0.8",
+    "@alertlogic/al-collector-js": "3.0.9",
     "async": "^3.2.4",
     "cfn-response": "1.0.1",
     "deep-equal": "^2.2.2",


### PR DESCRIPTION

### Problem Description
1.There are few CWE old collector which doesn’t have collector_id in lambda ENV  due to permission issue.
Status_id and stream are required field to send the status to collector status service.

> Status ID is a required parameter for Collectors Status, this should be unique to the collector (such as a UUID), which may usually indicate the host_id in case of agent or appliance, deployment_id for a deployment etc.


For Collectors Status, we would definitely need to ensure that we can safely identify different collectors within the account, otherwise we will have many collectors using statuses reported by other collectors.

2. Axios  lib sending data as well as body both.. 


### Solution Description
If there is no collector_id or stream or status object; then do not make send status api call.
Update the al-collector.js lib with latest version 3.0.9 to fix axios changes. -https://github.com/alertlogic/al-collector-js/pull/58

