### PR TITLE
Added few new params in NOUPDATE_CONFIG_PARAMS as it breaking the selfupdate with node version 18

### DIFF
--- a/al_aws_collector.js
+++ b/al_aws_collector.js
@@ -38,10 +38,13 @@ const NOUPDATE_CONFIG_PARAMS = [
     'LastUpdateStatusReason',
     'LastUpdateStatusReasonCode',
     'MasterArn',
+    'OptimizationStatus',
     'PackageType',
     'RevisionId',
     'Role',
+    'RuntimeVersionConfig',
     'State',
+    'SnapStart',
     'StateReason',
     'StateReasonCode',
     'Version'

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     }
   ],
   "devDependencies": {
-    "aws-sdk": "^2.1454.0",
     "aws-sdk-mock": "^5.8.0",
     "clone": "^2.1.2",
     "dotenv": "^16.3.1",
@@ -33,6 +32,7 @@
   },
   "dependencies": {
     "@alertlogic/al-collector-js": "3.0.10",
+    "aws-sdk": "^2.1454.0",
     "async": "^3.2.4",
     "cfn-response": "1.0.1",
     "deep-equal": "^2.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/al-aws-collector-js",
-  "version": "4.1.21",
+  "version": "4.1.22",
   "license": "MIT",
   "description": "Alert Logic AWS Collector Common Library",
   "repository": {


### PR DESCRIPTION
### Problem Description

- Self update is breaking while updating to runtime node version 18 with below error from aws sdk.
 `AWSC0006 Lambda self-update config error: MultipleValidationErrors: There were 2 validation errors:\n* UnexpectedParameter: Unexpected key 'OptimizationStatus' found in params.SnapStart\n* UnexpectedParameter: Unexpected key 'RuntimeVersionConfig' found in params",`
- With node 18 selfupdate failed with error `Cannot find module 'aws-sdk'\nRequire stack:\n- /var/task/node_modules/@alertlogic/al-aws-collector-js/al_aws_collector.js\n- /var/task/node_modules/@alertlogic/al-aws-collector-js/index.js\n- /var/task/index.js\n- /var/runtime/index.mjs`


### Solution Description

1. Added the below three parameters in NOUPDATE_CONFIG_PARAMS which will delete this parameter before call lambda.updateFunctionConfiguration.
2. Move the aws-sdk from devDependancy to dependancy
