### PR TITLE
ENG-52246 :Change the start date format to get the data from AWS cloudwatch.getMetricStatistics 

### DIFF
--- a/al_aws.js
+++ b/al_aws.js
@@ -132,7 +132,7 @@ var getLambdaMetrics = function (functionName, metricName, statistics, callback)
         MetricName: metricName,
         Namespace: 'AWS/Lambda',
         Statistics: ['Sum'],
-        StartTime: moment().subtract(AWS_STATISTICS_PERIOD_MINUTES, 'minutes').toISOString(),
+        StartTime: moment().subtract(AWS_STATISTICS_PERIOD_MINUTES, 'minutes'),
         EndTime: new Date(),
         Period: 60*AWS_STATISTICS_PERIOD_MINUTES   /* 15 mins as seconds */
     };
@@ -152,7 +152,7 @@ var getKinesisMetrics = function (streamName, metricName, statistics, callback) 
         MetricName: metricName,
         Namespace: 'AWS/Kinesis',
         Statistics: ['Sum'],
-        StartTime: moment().subtract(AWS_STATISTICS_PERIOD_MINUTES, 'minutes').toISOString(),
+        StartTime: moment().subtract(AWS_STATISTICS_PERIOD_MINUTES, 'minutes'),
         EndTime: new Date(),
         Period: 60*AWS_STATISTICS_PERIOD_MINUTES   /* 15 mins as seconds */
     };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/al-aws-collector-js",
-  "version": "4.1.23",
+  "version": "4.1.24",
   "license": "MIT",
   "description": "Alert Logic AWS Collector Common Library",
   "repository": {

--- a/statistics_templates.js
+++ b/statistics_templates.js
@@ -81,7 +81,7 @@ var getLambdaMetrics = function (functionName, metricName, callback) {
         MetricName: metricName,
         Namespace: 'AWS/Lambda',
         Statistics: ['Sum'],
-        StartTime: moment().subtract(AWS_STATISTICS_PERIOD_MINUTES, 'minutes').toISOString(),
+        StartTime: moment().subtract(AWS_STATISTICS_PERIOD_MINUTES, 'minutes'),
         EndTime: new Date(),
         Period: 60*AWS_STATISTICS_PERIOD_MINUTES   /* 15 mins as seconds */
     };
@@ -112,7 +112,7 @@ var getCustomMetrics = function (functionName, metricName, namespace, customDime
         MetricName: metricName,
         Namespace: namespace,
         Statistics: ['Sum'],
-        StartTime: moment().subtract(AWS_STATISTICS_PERIOD_MINUTES, 'minutes').toISOString(),
+        StartTime: moment().subtract(AWS_STATISTICS_PERIOD_MINUTES, 'minutes'),
         EndTime: new Date(),
         Period: 60 * AWS_STATISTICS_PERIOD_MINUTES   /* 15 mins as seconds */
     };
@@ -130,7 +130,7 @@ var getKinesisMetrics = function (streamName, metricName, callback) {
         MetricName: metricName,
         Namespace: 'AWS/Kinesis',
         Statistics: ['Sum'],
-        StartTime: moment().subtract(AWS_STATISTICS_PERIOD_MINUTES, 'minutes').toISOString(),
+        StartTime: moment().subtract(AWS_STATISTICS_PERIOD_MINUTES, 'minutes'),
         EndTime: new Date(),
         Period: 60*AWS_STATISTICS_PERIOD_MINUTES   /* 15 mins as seconds */
     };


### PR DESCRIPTION
### Problem Description
Not returning the error or  dataPoints object when we call the cloudwatch.getMetricStatistics for predefine AWS metrics and custom metrics.
### Solution Description
As per  AWS v3 ,startDate should be in date object format ,so change the startDate from string to date object.

