### PR TITLE
change the variable name as per aws-sdk v3

### DIFF
--- a/al_aws.js
+++ b/al_aws.js
@@ -28,7 +28,7 @@ const MAX_RANDOM_VALUE = 3000;
 const AWS_STATISTICS_PERIOD_MINUTES = 15;
 const MAX_ERROR_MSG_LEN = 1024;
 const LAMBDA_CONFIG = {
-        maxRetries: 10
+        maxAttempts: 10
 };
 const LAMBDA_UPDATE_RETRY = {
         times: 20,

--- a/health_checks.js
+++ b/health_checks.js
@@ -33,7 +33,7 @@ const INGEST_INVALID_ENCODING = {
 
 function checkCloudFormationStatus(stackName, callback) {
     var cloudformation = new CloudFormation({
-        maxRetries:7,
+        maxAttempts:7,
         retryDelayOptions: {
             customBackoff: m_alAws.customBackoff
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/al-aws-collector-js",
-  "version": "4.1.24",
+  "version": "4.1.25",
   "license": "MIT",
   "description": "Alert Logic AWS Collector Common Library",
   "repository": {


### PR DESCRIPTION
### Problem Description
During selfupdate collector goes in retry and never stop which result in rate limit.
Aws-sdk v3 version change the variable name maxRetries to maxAttempts and so exiting code not woking in retry mechanism.

### Solution Description

Updated the variable name from maxRetries  to maxAttempts.
