### PR TITLE
[ENG-55435]: Upgrade node.js 18 to latest version 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/al-aws-collector-js",
-  "version": "4.1.25",
+  "version": "4.1.26",
   "license": "MIT",
   "description": "Alert Logic AWS Collector Common Library",
   "repository": {
@@ -21,26 +21,26 @@
     }
   ],
   "devDependencies": {
-    "@aws-sdk/client-cloudformation": "^3.427.0",
-    "@aws-sdk/client-cloudwatch": "^3.427.0",
-    "@aws-sdk/client-kms": "^3.427.0",
-    "@aws-sdk/client-lambda": "^3.427.0",
-    "@aws-sdk/client-s3": "^3.427.0",
+    "@aws-sdk/client-cloudformation": "^3.592.0",
+    "@aws-sdk/client-cloudwatch": "^3.592.0",
+    "@aws-sdk/client-kms": "^3.592.0",
+    "@aws-sdk/client-lambda": "^3.592.0",
+    "@aws-sdk/client-s3": "^3.592.0",
     "clone": "^2.1.2",
-    "dotenv": "^16.3.1",
+    "dotenv": "^16.4.5",
     "jshint": "^2.13.6",
-    "mocha": "^10.2.0",
-    "nyc": "^15.1.0",
+    "mocha": "^10.4.0",
+    "nyc": "^17.0.0",
     "rewire": "^7.0.0",
-    "sinon": "^15.2.0"
+    "sinon": "^18.0.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "3.0.10",
-    "async": "^3.2.4",
+    "@alertlogic/al-collector-js": "3.0.11",
+    "async": "^3.2.5",
     "cfn-response": "1.0.1",
-    "deep-equal": "^2.2.2",
-    "moment": "^2.29.4",
-    "winston": "^3.10.0"
+    "deep-equal": "^2.2.3",
+    "moment": "^2.30.1",
+    "winston": "^3.13.0"
   },
   "author": "Alert Logic Inc."
 }

--- a/ps_spec.yml
+++ b/ps_spec.yml
@@ -8,7 +8,7 @@ stages:
             - pull_request
             - pull_request:
                 trigger_phrase: test it
-        image: node:18
+        image: node:20
         compute_size: small
         commands:
             - make test
@@ -17,7 +17,7 @@ stages:
         name: Master Push - Publish
         when:
             - push: ['master']
-        image: node:18
+        image: node:20
         compute_size: small
         commands:
             - make test


### PR DESCRIPTION
### Problem Description
AWS lambda runtime started support node.js 20.x

### Solution Description
Updated the runtime node.js version from 18 to 20.x

