### PR TITLE
[al-aws-collector-js]Npm packages updated for vulnerability fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/al-aws-collector-js",
-  "version": "4.1.28",
+  "version": "4.1.29",
   "license": "MIT",
   "description": "Alert Logic AWS Collector Common Library",
   "repository": {
@@ -21,26 +21,26 @@
     }
   ],
   "devDependencies": {
-    "@aws-sdk/client-cloudformation": "^3.592.0",
-    "@aws-sdk/client-cloudwatch": "^3.592.0",
-    "@aws-sdk/client-kms": "^3.592.0",
-    "@aws-sdk/client-lambda": "^3.592.0",
-    "@aws-sdk/client-s3": "^3.592.0",
+    "@aws-sdk/client-cloudformation": "^3.775.0",
+    "@aws-sdk/client-cloudwatch": "^3.775.0",
+    "@aws-sdk/client-kms": "^3.775.0",
+    "@aws-sdk/client-lambda": "^3.775.0",
+    "@aws-sdk/client-s3": "^3.775.0",
     "clone": "^2.1.2",
-    "dotenv": "^16.4.5",
+    "dotenv": "^16.4.7",
     "jshint": "^2.13.6",
-    "mocha": "^10.4.0",
-    "nyc": "^17.0.0",
+    "mocha": "^10.8.2",
+    "nyc": "^17.1.0",
     "rewire": "^7.0.0",
-    "sinon": "^18.0.1"
+    "sinon": "^20.0.0"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "3.0.14",
-    "async": "^3.2.5",
+    "@alertlogic/al-collector-js": "3.0.15",
+    "async": "^3.2.6",
     "cfn-response": "1.0.1",
     "deep-equal": "^2.2.3",
     "moment": "^2.30.1",
-    "winston": "^3.13.0"
+    "winston": "^3.17.0"
   },
   "author": "Alert Logic Inc."
 }


### PR DESCRIPTION
### Problem Description
Update the Dependancy due to which below vulnerability are found :
Customer had provided 4 vulnerabilities that they have detected against the GuardDuty Collector
CVEs:
CVE-2024-21538
CVE-2024-57965
CVE-2025-27152
CVE-2025-27789


### Solution Description
npm packages are updated to fix above CVEs

1.   "mocha": "^10.8.2"
2.   "nyc": "^17.1.0"
3.   "axios": "^1.8.4"
4.   "debug": "4.4.0"
5.   "protobufjs": "^7.4.0"
6.   "@aws-sdk/client-cloudformation": "^3.775.0
7.   "@aws-sdk/client-cloudwatch": "^3.775.0
9.   "@aws-sdk/client-kms": "^3.775.0
11.  "@aws-sdk/client-lambda": "^3.775.0
12.  "@aws-sdk/client-s3": "^3.775.0
13.   "sinon": "^20.0.0"
14.   "winston": "^3.17.0"
15.    "async": "^3.2.6"
16.   "@alertlogic/al-collector-js": "3.0.15"