### PR TITLE
Use the callback function to explicitly return success or failure Instead of Context

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/al-aws-collector-js",
-  "version": "4.1.29",
+  "version": "4.2.0",
   "license": "MIT",
   "description": "Alert Logic AWS Collector Common Library",
   "repository": {


### PR DESCRIPTION
### Problem Description
In some scenarios, the code either does not reach context.succeed, or this method is no longer mentioned in the AWS documentation. Therefore, it is uncertain whether the SQS message is always deleted when the Lambda function succeeds, which may result in duplicate SQS messages remaining in the queue

### Solution Description
The context.succeed and context.fail methods are no longer recommended and are not present in the current AWS documentation ([AWS Lambda Node.js context](https://docs.aws.amazon.com/lambda/latest/dg/nodejs-context.html )). Instead, use the callback function to explicitly return success or failure.


