### PR TITLE
Migrate Lambda runtime support to nodejs24.x and fix CFN response logging and processLog fail-fast

### DIFF
--- a/modern/al_aws_collector_v2.js
+++ b/modern/al_aws_collector_v2.js
@@ -647,19 +647,25 @@ class AlAwsCollectorV2 {
                 filterJson: '',
                 filterRegexp: ''
             };
-            const payloadObject = await new Promise((resolve, reject) => {
-                alCollector.AlLog.buildPayload(
-                    buildPayloadObj, (err, payloadObj) => {
-                        if (err) {
-                            reject(err);
-                        } else {
-                            resolve(payloadObj);
-                        }
-                    });
-            });
-            await collector.send(payloadObject.payload, false, AlAwsCollectorV2.IngestTypes.LOGMSGS);
-            const stats = collector.prepareLmcStats(payloadObject.raw_count, payloadObject.raw_bytes);
-            return await collector.send(JSON.stringify([stats]), true, AlAwsCollectorV2.IngestTypes.LMCSTATS);
+            try {
+                const payloadObject = await new Promise((resolve, reject) => {
+                    alCollector.AlLog.buildPayload(
+                        buildPayloadObj, (err, payloadObj) => {
+                            if (err) {
+                                reject(err);
+                            } else {
+                                resolve(payloadObj);
+                            }
+                        });
+                });
+                // Fail-fast: if LOGMSGS send fails we must NOT call the LMCSTATS send.
+                await collector.send(payloadObject.payload, false, AlAwsCollectorV2.IngestTypes.LOGMSGS);
+                const stats = collector.prepareLmcStats(payloadObject.raw_count, payloadObject.raw_bytes);
+                return await collector.send(JSON.stringify([stats]), true, AlAwsCollectorV2.IngestTypes.LMCSTATS);
+            } catch (error) {
+                logger.error(`AWSC0023 processLog aborted: ${error && error.message ? error.message : error}`);
+                throw error;
+            }
         }
     }
 
@@ -693,6 +699,7 @@ class AlAwsCollectorV2 {
             }
         } catch (error) {
             logger.error(`AWSC0013 Error sending data to Alertlogic ingest: ${error.message}`);
+            throw error;
         }
     }
     /**

--- a/modern/cfn_response_fetch.js
+++ b/modern/cfn_response_fetch.js
@@ -42,10 +42,19 @@ const response = {
                 },
                 json: false  // Don't parse response as JSON
             });
-            console.log('CFN Response PUT result:', putResponse);
-            
+
+            // RestServiceClient.put resolves with the response body only. For CFN
+            // pre-signed S3 PUT URLs the body is empty on success, so we only log
+            // body when there is something meaningful to print.
+            if (putResponse && !(typeof putResponse === 'object' && Object.keys(putResponse).length === 0)){
+                const bodySummary = typeof putResponse === 'string' ? putResponse : JSON.stringify(putResponse);
+                console.log(`CFN Response PUT succeeded. status=${responseStatus} body=${bodySummary}`);
+            } else {
+                console.log(`CFN Response PUT succeeded. status=${responseStatus}`);
+            }
+
         } catch (error) {
-            console.error('CFN Response Error:', error);
+            console.error('CFN Response failed.', error);
             // Just log the error and continue
         }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alertlogic/al-aws-collector-js",
-  "version": "4.2.5",
+  "version": "4.2.6",
   "license": "MIT",
   "description": "Alert Logic AWS Collector Common Library",
   "repository": {
@@ -35,7 +35,7 @@
     "sinon": "^21.0.1"
   },
   "dependencies": {
-    "@alertlogic/al-collector-js": "3.0.20",
+    "@alertlogic/al-collector-js": "3.0.23",
     "async": "^3.2.6",
     "cfn-response": "1.0.1",
     "deep-equal": "^2.2.3",

--- a/ps_spec.yml
+++ b/ps_spec.yml
@@ -8,7 +8,7 @@ stages:
             - pull_request
             - pull_request:
                 trigger_phrase: test it
-        image: node:22
+        image: node:24
         compute_size: small
         commands:
             - make test
@@ -17,7 +17,7 @@ stages:
         name: Master Push - Publish
         when:
             - push: ['master']
-        image: node:22
+        image: node:24
         compute_size: small
         commands:
             - make test

--- a/test/mordernTest/al_aws_collector_v2_test.js
+++ b/test/mordernTest/al_aws_collector_v2_test.js
@@ -450,14 +450,17 @@ describe('AlAwsCollectorV2 tests', function () {
                 invokedFunctionArn: colMock.FUNCTION_ARN,
                 fail: (error) => {
                     assert.ok(error);
-                    sinon.assert.calledOnce(ingestCLogmsgsStub);
                 }
             };
 
             const creds = AlAwsCollectorV2.load();
             var collector = new AlAwsCollectorV2(mockContext, 'cwe', AlAwsCollectorV2.IngestTypes.LMCSTATS, '1.0.0', creds, function () { });
             var data = 'some-data-to-send';
-            await collector.send(data, true, AlAwsCollectorV2.IngestTypes.LMCSTATS);
+            await assert.rejects(
+                () => collector.send(data, true, AlAwsCollectorV2.IngestTypes.LMCSTATS)
+            );
+            sinon.assert.calledOnce(ingestCLogmsgsStub);
+            ingestCLogmsgsStub.restore();
         });
         it('send vpcflow success', async function () {
             const creds = await AlAwsCollectorV2.load();
@@ -610,6 +613,88 @@ describe('AlAwsCollectorV2 tests', function () {
             await collector.reportCWMetric(param);
             sinon.assert.calledOnce(putMetricDataStub);
             putMetricDataStub.restore();
+        });
+    });
+
+    describe('processLog method tests', function () {
+        const messages = [{ msg: 'hello' }];
+        const formatFun = (m) => m;
+        let sendLogmsgsStub;
+        let sendLmcstatsStub;
+
+        afterEach(() => {
+            if (m_alCollector.AlLog.buildPayload.restore) {
+                m_alCollector.AlLog.buildPayload.restore();
+            }
+            if (sendLogmsgsStub && sendLogmsgsStub.restore) {
+                sendLogmsgsStub.restore();
+                sendLogmsgsStub = undefined;
+            }
+            if (sendLmcstatsStub && sendLmcstatsStub.restore) {
+                sendLmcstatsStub.restore();
+                sendLmcstatsStub = undefined;
+            }
+        });
+
+        it('processLog rejects and does not send when buildPayload fails', async function () {
+            sinon.stub(m_alCollector.AlLog, 'buildPayload').callsFake((opts, cb) => {
+                return cb(new Error('build failed'));
+            });
+
+            const creds = await AlAwsCollectorV2.load();
+            const collector = new AlAwsCollectorV2(
+                context, 'cwe', AlAwsCollectorV2.IngestTypes.LOGMSGS, '1.0.0', creds, formatFun);
+            const sendSpy = sinon.spy(collector, 'send');
+
+            await assert.rejects(
+                () => collector.processLog(messages, formatFun, null),
+                /build failed/
+            );
+            sinon.assert.notCalled(sendSpy);
+            sendSpy.restore();
+        });
+
+        it('processLog does not call LMCSTATS send when LOGMSGS send fails', async function () {
+            sinon.stub(m_alCollector.AlLog, 'buildPayload').callsFake((opts, cb) => {
+                return cb(null, { payload: 'p', raw_count: 1, raw_bytes: 10 });
+            });
+            const logmsgsErr = {
+                message: 'logmsgs ingest failed',
+                response: { status: 400 }
+            };
+            sendLogmsgsStub = sinon.stub(m_alCollector.IngestC.prototype, 'sendLogmsgs')
+                .callsFake(() => Promise.reject(logmsgsErr));
+            sendLmcstatsStub = sinon.stub(m_alCollector.IngestC.prototype, 'sendLmcstats')
+                .callsFake(() => Promise.resolve());
+
+            const creds = await AlAwsCollectorV2.load();
+            const collector = new AlAwsCollectorV2(
+                context, 'cwe', AlAwsCollectorV2.IngestTypes.LOGMSGS, '1.0.0', creds, formatFun);
+
+            await assert.rejects(
+                () => collector.processLog(messages, formatFun, null),
+                (err) => err && err.errorCode === 'AWSC0018'
+            );
+            sinon.assert.calledOnce(sendLogmsgsStub);
+            sinon.assert.notCalled(sendLmcstatsStub);
+        });
+
+        it('processLog sends LOGMSGS and LMCSTATS when both succeed', async function () {
+            sinon.stub(m_alCollector.AlLog, 'buildPayload').callsFake((opts, cb) => {
+                return cb(null, { payload: 'p', raw_count: 1, raw_bytes: 10 });
+            });
+            sendLogmsgsStub = sinon.stub(m_alCollector.IngestC.prototype, 'sendLogmsgs')
+                .callsFake(() => Promise.resolve());
+            sendLmcstatsStub = sinon.stub(m_alCollector.IngestC.prototype, 'sendLmcstats')
+                .callsFake(() => Promise.resolve());
+
+            const creds = await AlAwsCollectorV2.load();
+            const collector = new AlAwsCollectorV2(
+                context, 'cwe', AlAwsCollectorV2.IngestTypes.LOGMSGS, '1.0.0', creds, formatFun);
+
+            await collector.processLog(messages, formatFun, null);
+            sinon.assert.calledOnce(sendLogmsgsStub);
+            sinon.assert.calledOnce(sendLmcstatsStub);
         });
     });
 });

--- a/test/mordernTest/cfn_response_fetch_test.js
+++ b/test/mordernTest/cfn_response_fetch_test.js
@@ -1,0 +1,106 @@
+const assert = require('assert');
+const sinon = require('sinon');
+const m_alCollector = require('@alertlogic/al-collector-js');
+const response = require('../../modern/cfn_response_fetch');
+
+const baseEvent = {
+    StackId: 'arn:aws:cloudformation:us-east-1:123:stack/foo/abcd',
+    RequestId: 'req-1',
+    LogicalResourceId: 'MyResource',
+    ResponseURL: 'https://cfn-response.example.com/upload?signature=x'
+};
+
+const baseContext = {
+    logStreamName: 'log-stream-1'
+};
+
+describe('cfn_response_fetch logging tests', function () {
+    let putStub;
+    let logSpy;
+    let errSpy;
+
+    afterEach(() => {
+        if (putStub && putStub.restore) {
+            putStub.restore();
+        }
+        if (logSpy && logSpy.restore) {
+            logSpy.restore();
+        }
+        if (errSpy && errSpy.restore) {
+            errSpy.restore();
+        }
+    });
+
+    it('logs a complete success message without body when PUT response is empty', async function () {
+        putStub = sinon.stub(m_alCollector.RestServiceClient.prototype, 'put').resolves('');
+        logSpy = sinon.spy(console, 'log');
+
+        await response.send(baseEvent, baseContext, response.SUCCESS, {});
+
+        const successLog = logSpy.getCalls().find(
+            (c) => typeof c.args[0] === 'string' && c.args[0].startsWith('CFN Response PUT succeeded')
+        );
+        assert.ok(successLog, 'expected a complete success log line');
+        assert.match(successLog.args[0], /status=SUCCESS/);
+        assert.doesNotMatch(successLog.args[0], /body=/);
+    });
+
+    it('logs a complete success message without body when PUT response is an empty object', async function () {
+        putStub = sinon.stub(m_alCollector.RestServiceClient.prototype, 'put').resolves({});
+        logSpy = sinon.spy(console, 'log');
+
+        await response.send(baseEvent, baseContext, response.SUCCESS, {});
+
+        const successLog = logSpy.getCalls().find(
+            (c) => typeof c.args[0] === 'string' && c.args[0].startsWith('CFN Response PUT succeeded')
+        );
+        assert.ok(successLog);
+        assert.doesNotMatch(successLog.args[0], /body=/);
+    });
+
+    it('includes the returned body in the success log when present', async function () {
+        putStub = sinon.stub(m_alCollector.RestServiceClient.prototype, 'put').resolves('ok-body');
+        logSpy = sinon.spy(console, 'log');
+
+        await response.send(baseEvent, baseContext, response.SUCCESS, {});
+
+        const successLog = logSpy.getCalls().find(
+            (c) => typeof c.args[0] === 'string' && c.args[0].startsWith('CFN Response PUT succeeded')
+        );
+        assert.ok(successLog);
+        assert.match(successLog.args[0], /body=ok-body/);
+    });
+
+    it('logs the error object on PUT failure with status info available', async function () {
+        const err = new Error('forbidden');
+        err.response = { status: 403, statusText: 'Forbidden' };
+        putStub = sinon.stub(m_alCollector.RestServiceClient.prototype, 'put').rejects(err);
+        errSpy = sinon.spy(console, 'error');
+
+        await response.send(baseEvent, baseContext, response.FAILED, { Error: 'x' });
+
+        const errLog = errSpy.getCalls().find(
+            (c) => typeof c.args[0] === 'string' && c.args[0].startsWith('CFN Response failed.')
+        );
+        assert.ok(errLog, 'expected a failure log line');
+        // The error object is passed as the second argument so operators can see status/statusText
+        assert.strictEqual(errLog.args[1], err);
+        assert.strictEqual(errLog.args[1].response.status, 403);
+        assert.strictEqual(errLog.args[1].response.statusText, 'Forbidden');
+    });
+
+    it('logs the error object on PUT failure when only a message is present', async function () {
+        const err = new Error('boom');
+        putStub = sinon.stub(m_alCollector.RestServiceClient.prototype, 'put').rejects(err);
+        errSpy = sinon.spy(console, 'error');
+
+        await response.send(baseEvent, baseContext, response.FAILED, { Error: 'x' });
+
+        const errLog = errSpy.getCalls().find(
+            (c) => typeof c.args[0] === 'string' && c.args[0].startsWith('CFN Response failed.')
+        );
+        assert.ok(errLog);
+        assert.strictEqual(errLog.args[1], err);
+        assert.strictEqual(errLog.args[1].message, 'boom');
+    });
+});


### PR DESCRIPTION
### Problem Description
 The collector library with AWS Lambda need to support nodejs24.x and hardens two reliability issues observed in production: CloudFormation custom-resource PUT logging that looked incomplete, and [processLog] continuing to call the next ingest API even after a prior API call failed.

### Solution Description

1. Runtime migration : Updated CI image to node:24 in both stages of ps_spec.yml.
2. CFN response logging fixes : When body is present, print a compact body summary alongside status.Simplified the failure path to a single clear error log line.
3. processLog fail-fast:  Wraps its sequential calls in try/catch, logs a dedicated message (AWSC0023), and aborts before invoking LMCSTATS when LOGMSGS fails.
